### PR TITLE
Python kernel: tool results as live variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,36 @@ tool that normally asks permission still asks when it is called from Python —
 otherwise an approved cell would be a way to edit files and run shell commands
 with no prompt at all, which is the gate the model would be routing around.
 
+### Does telling the model help?
+
+`bench/python-tool.js` measures it, because the answer was not obvious. The tool
+description carries three worked cells; the benchmark runs the same task with
+and without them, on a fixture where exports and file length vary independently
+so that the densest file is not the one with the most exports — no single tool
+call gets there.
+
+```
+model      nemotron-3-nano:4b        8 repeats per arm
+
+arm               correct   used python   calls   time
+without examples  0/8       0/8           7.1     9s
+with examples     3/8       8/8           3.8     6s
+```
+
+Tool selection is the decisive change: never reached for, to always reached for,
+at roughly half the tool calls. Accuracy moves from never right to sometimes
+right — the surviving failures are ordinary Python bugs, a different one each
+run, which is what a 4B model writing code looks like rather than a missing
+instruction.
+
+A fourth note, explaining that `glob` output begins with a summary line, was
+tried against the commonest error and made no measurable difference. It was
+removed rather than kept on the strength of the theory.
+
+```bash
+node bench/python-tool.js --repeats 8 qwen3:8b
+```
+
 It is **additive**, and that is deliberate. The ordinary tools remain and the
 model is free to ignore Python entirely, because writing correct code against
 live state is harder than emitting a tool call — and a bad line here can leave a

--- a/README.md
+++ b/README.md
@@ -406,6 +406,43 @@ together.
 Results over 256 KB are not stored — a runaway command belongs in the overflow
 file, not the session database.
 
+## Python, with results already in scope
+
+`recall` can search a stored result or slice it, and nothing else, because those
+are the two operations written by hand. The `python` tool closes that gap: a
+session-long interpreter where **every stored handle arrives as a variable**.
+
+```python
+lines = [l for l in read_1.splitlines() if l.startswith('## ')]
+len(lines)
+```
+
+`read_1` was not fetched here. It was bound because an earlier `read_file` call
+produced it, and it holds the whole file, not the window that was shown.
+Variables, imports and functions persist between calls, and a bare expression on
+the last line returns its value the way a notebook does.
+
+This is the part of [Prime Agent's](https://github.com/PrimeIntellect-ai/prime-agent)
+design that made results worth naming — theirs is a live IPython kernel, this is
+a plain interpreter and newline-delimited JSON, which is enough to make a result
+a value you can compute over rather than a lookup you can only re-read.
+
+It is **additive**, and that is deliberate. The ordinary tools remain and the
+model is free to ignore Python entirely, because writing correct code against
+live state is harder than emitting a tool call — and a bad line here can leave a
+namespace that later cells inherit. The tool asks permission like `run_command`,
+runs with the same sanitised environment so a cell cannot read your API keys,
+and is not offered at all when no interpreter is present.
+
+Detection runs the interpreter rather than trusting the name: on Windows
+`python3` is frequently an App Execution Alias that prints "Python was not
+found" and **exits 0**, so a `which`-style check reports success and the kernel
+then fails at the first cell with nothing to explain it.
+
+A cell that does not finish within 30 seconds is killed. The kernel is
+single-threaded, so one hung cell would otherwise block every cell after it —
+and the loss of the namespace is reported rather than left to be discovered.
+
 ## Compaction
 
 A long session eventually sends more history than the model can hold. Ollama

--- a/README.md
+++ b/README.md
@@ -387,8 +387,16 @@ database under a short handle, and the result the model reads ends with it:
 
 ```
   ✓ read README.md                                294 of 638 lines
-    [saved as read_1 — recall it instead of running this again]
+    [saved as readme_md — recall it instead of running this again]
 ```
+
+Handles are named after what they hold, not the order they arrived in:
+`stats_js`, `grep_completionrate`, `npm_test`. `read_1` said which tool ran and
+when, so the model had to fetch a result to remember what was in it. The name is
+also the variable name in the Python kernel, so it has to be a valid identifier
+and must never shadow a tool function — a handle called `grep` would replace the
+tool with a string and break the next cell in a way that looks nothing like the
+cause.
 
 `recall` reads it back — whole, sliced with `start_line`/`end_line`, or searched
 with a pattern. A model that read a 600-line README in six twenty-line calls can

--- a/README.md
+++ b/README.md
@@ -457,6 +457,25 @@ Detection runs the interpreter rather than trusting the name: on Windows
 found" and **exits 0**, so a `which`-style check reports success and the kernel
 then fails at the first cell with nothing to explain it.
 
+The namespace is **saved between runs**, so resuming a session brings back the
+variables, imports and helpers from the last one:
+
+```
+[restored from the last session: counts, json, pattern, rate, re]
+```
+
+Saved per variable rather than all at once, so one open file handle cannot take
+everything else with it — what could not be saved is named. Two things pickle
+cannot store are handled specially, because they are the commonest things a
+namespace holds: a **module** is recorded by name and imported again, and a
+**function or class** defined in a cell is saved as its source and replayed. A
+name later rebound to a value is restored as that value, not resurrected as the
+old function.
+
+The write is atomic, and a corrupt or missing snapshot is not an error — the
+kernel starts empty and says so, because losing variables is a nuisance while
+refusing to start is a broken session.
+
 A cell that does not finish within 30 seconds is killed. The kernel is
 single-threaded, so one hung cell would otherwise block every cell after it —
 and the loss of the namespace is reported rather than left to be discovered.

--- a/README.md
+++ b/README.md
@@ -427,6 +427,24 @@ design that made results worth naming — theirs is a live IPython kernel, this 
 a plain interpreter and newline-delimited JSON, which is enough to make a result
 a value you can compute over rather than a lookup you can only re-read.
 
+Tools are callable too, so a cell can drive a loop of them for one model
+round-trip instead of one per file:
+
+```python
+hits = grep(pattern='completionRate')
+files = sorted({l.split(':')[0] for l in hits.splitlines()[1:]})
+sizes = {f: len(read_file(path=f)) for f in files}
+```
+
+Each call blocks the cell until the host answers, so it reads exactly like the
+function it appears to be. A tool that fails raises `ToolError`, which the code
+around it can catch and act on.
+
+**Approving the scratchpad does not approve what the scratchpad can reach.** A
+tool that normally asks permission still asks when it is called from Python —
+otherwise an approved cell would be a way to edit files and run shell commands
+with no prompt at all, which is the gate the model would be routing around.
+
 It is **additive**, and that is deliberate. The ordinary tools remain and the
 model is free to ignore Python entirely, because writing correct code against
 live state is harder than emitting a tool call — and a bad line here can leave a

--- a/README.md
+++ b/README.md
@@ -2,775 +2,164 @@
 
 A local-first coding agent for the terminal, powered by Ollama.
 
-Cloi is a general-purpose agent, not a single-purpose tool: you talk to it, and
-it reads, searches, writes, and edits files and runs commands in your workspace
-to answer you. Everything runs on your machine. No API key, no data leaving the
-host.
-
-This is a rewrite of the original Cloi, which was a fixed
-`analyze → classify → patch` debugging pipeline — the model could never say
-"show me the caller of this function first." The architecture here follows
-patterns from [hermes-agent](https://github.com/NousResearch/hermes-agent) and
-[opencode](https://github.com/anomalyco/opencode).
-
-## Requirements
-
-- Node.js 22.5 or newer (uses the built-in `node:sqlite`, so no native build)
-- [Ollama](https://ollama.com) running locally
-- A **tool-capable** model — check with `ollama show <model>` and look for
-  `tools` under Capabilities
+You talk to it; it reads, searches, writes and edits files and runs commands in
+your workspace to answer you. Everything runs on your machine — no API key, no
+data leaving the host.
 
 ```bash
-npm install
-cloi setup      # measures the machine, picks models, downloads them
+npm install -g @cloi-ai/cloi
 cloi
 ```
 
-`cloi setup` runs automatically on first use if no config exists.
-
-Startup fails early and loudly if Ollama is unreachable, the model is missing,
-or the model cannot call tools — each with the exact command to fix it.
-Discovering any of those mid-turn produces baffling behaviour instead of an
-error.
-
-## Choosing models
-
-The hardest decision for a new user is which model to run, and getting it wrong
-produces an agent that looks *broken* rather than one that looks slow. So it is
-measured rather than guessed.
-
-`cloi setup` reads VRAM, system RAM and core count, then proposes two models
-against **different constraints** — which is the whole idea:
-
-- The **primary** runs every step of every turn, so it must fit in VRAM. A model
-  that spills is not slightly slower, it is several times slower, and that cost
-  is paid on each of the dozen-odd model calls a turn makes.
-- The **escalation** model runs rarely, only when a turn is already going wrong,
-  so it is allowed to spill. It only has to fit in RAM. A few slow minutes on a
-  turn that would otherwise fail outright is a good trade.
+`cloi setup` runs automatically the first time and picks models that fit your
+hardware. Requires [Ollama](https://ollama.com), Node 22.5+, and a tool-capable
+model.
 
 ```
-NVIDIA GeForce RTX 5060 Laptop GPU · 8.0 GB VRAM · 31.4 GB RAM · 20 cores
+  █▀▀ █   █▀█ █   fallback  qwen3:30b-a3b
+  █▄▄ █▄▄ █▄█ █   context   16k
+                  root      ~/my-project
 
-primary   qwen3:8b       5.2 GB · best small model for agent loops
-fallback  qwen3:30b-a3b   18 GB · mixture-of-experts: 3B active, so it stays
-                                  fast even when it spills to RAM
-```
-
-Sample recommendations:
-
-| Machine | Primary | Escalation |
-|---|---|---|
-| No GPU, 16 GB RAM | `qwen3:4b` | `qwen3:14b` |
-| 6 GB VRAM, 16 GB RAM | `qwen3:4b` | `qwen3:14b` |
-| 8 GB VRAM, 32 GB RAM | `qwen3:8b` | `qwen3:30b-a3b` |
-| 16 GB VRAM, 32 GB RAM | `qwen3:14b` | `qwen3:30b-a3b` |
-| 24 GB VRAM, 64 GB RAM | `qwen3:32b` | — |
-
-Five details that matter, all of them corrected by measurement rather than
-reasoned from first principles:
-
-- **The bar is ~60% VRAM residency, not a full fit.** On an 8 GB card only a 4B
-  model fits entirely, and dropping two tiers of capability to avoid a 20% spill
-  is the wrong trade.
-- **Fit uses an additive reserve, not a multiplier.** The overhead beyond the
-  weights is the KV cache, which scales with the *context window* rather than
-  model size. A multiplier refused a 20 GB model on a 24 GB card that holds it
-  fine.
-- **A primary is stepped down when it would leave nothing to escalate to.** A
-  faster primary plus a working fallback beats a bloated primary alone.
-- **A mixture-of-experts model is preferred for escalation when it will spill.**
-  Only its active parameters cost time, so `qwen3:30b-a3b` stays usable on CPU
-  where a dense model of the same footprint would not.
-- **Thresholds sit under the nominal card size.** An "8 GB" card reports 8151
-  MiB — 7.96 GiB — so a naive `>= 8` would quietly drop it a tier.
-
-### Which models, and why those
-
-The catalog spans families rather than betting on one vendor, and entries were
-chosen from a local run through this registry — not from public leaderboards,
-which use their own tools and prompts.
-
-`bench/compare.js` runs candidate models against the real eight tools with
-escalation and judging disabled, on tasks with checkable answers:
-
-Eight tasks across three difficulty bands, three repeats each, scored
-mechanically — a regex over the answer, or the exit code of the project's own
-test suite:
-
-```
-model                  pass rate      easy   medium   hard   tok/s (sd)
-qwen3:8b               11/24 (46%)    8/9    3/9      0/6    33.7 (5.2)
-nemotron-3-nano:4b     15/24 (63%)    8/9    7/9      0/6    98.8 (18.7)
-```
-
-Three results shaped the catalog:
-
-- **Nemotron wins on a smaller model.** 63% against 46%, and 7/9 against 3/9 on
-  medium tasks, at 2.8 GB and roughly three times the throughput. So catalog
-  *tier means measured capability, not size* — ordering by size would hand an
-  8 GB card the weaker model purely because it is bigger.
-- **Hard tasks are 0/12 for both.** Not one pass in twelve attempts at tracing a
-  bug across files. That is the ceiling, stated with real n rather than inferred.
-- **Neither over-triggers.** Both scored 3/3 on a task that passes only if *no*
-  tool is called, which the relevance/irrelevance splits in public benchmarks
-  suggested was a genuine risk.
-
-A `~` marks any task passed only sometimes — unreliability is a different
-failure from incapability, and matters more inside a loop.
-
-An earlier three-task version of this benchmark ranked the two models as tied.
-It was too easy to discriminate, and its scorer was wrong: an answer of "it is in
-stats.js, **not** report.js" was marked incorrect for naming the distractor —
-penalising precision. Scoring now takes the first non-negated file mentioned,
-verified against twelve hand-written cases covering both word orders.
-
-**Gemma 4** is deliberately absent despite being tool-capable and Apache-2.0. It
-came last here — hitting the iteration ceiling on a task the others finished in
-four steps — which matches independent results giving Qwen 3.6 large agentic
-margins (SWE-bench +21.4, MCPMark +18.9, TAU2 +13). Gemma 4 wins math and
-multimodal; this loop uses neither.
-
-**Nemotron 3 Super and Ultra** are 120B and 550B, and Ultra is cloud-only on
-Ollama, so neither fits a laptop.
-
-Run it yourself against anything you like:
-
-```bash
-node bench/compare.js qwen3:8b nemotron-3-nano:4b your-model:tag
-```
-
-### The prediction is checked against reality
-
-Probes read the card; they can still be wrong on hardware nobody has tested. So
-after the primary is pulled, setup loads it and asks Ollama where it actually
-went:
-
-```
-82% of qwen3:8b is resident in VRAM
-```
-
-That number comes from `size_vram / size` on `/api/ps`, which reflects **Ollama's
-own GPU detection** — covering NVIDIA, AMD, Intel and Metal, including hardware
-these probes cannot read. If residency comes back below 40%, the primary is
-stepped down automatically and you are told why.
-
-The constants are calibrated against that measurement: on this machine the
-prediction was 82% and the observed value 80%, a two-point error. There is no
-Ollama endpoint reporting card capacity — `/api/gpu`, `/api/hardware`,
-`/api/system` all 404 — so the placement of a real model is the closest thing to
-ground truth available.
-
-VRAM is probed in order of how reliable the number is: `nvidia-smi`, then
-`rocm-smi` for AMD, then the Windows display-adapter registry (covering AMD and
-Intel), then Linux sysfs. Apple Silicon is treated as unified memory at roughly
-two thirds of system RAM.
-
-Two Windows traps are worth naming, since both silently produce a wrong answer
-rather than an error. WMI's `AdapterRAM` is a 32-bit field that reports *any*
-card above 4 GB as exactly 4 GB — so the registry's 64-bit `qwMemorySize` is
-used instead. And that value is a *flat* property whose name contains a dot, so
-it must be quoted: dot-traversal reads `null` and makes every machine look like
-it has no GPU.
-
-Every probe returns null rather than a guess. If nothing is detectable the
-recommendation drops to a CPU-sized model, because suggesting something too
-large fails confusingly while suggesting something too small merely
-underperforms.
-
-Downloads go through Ollama's HTTP API rather than the `ollama` binary, which
-may not be on `PATH` even when the server is reachable. A failed download never
-discards the recommendation — the config is written either way, so you are never
-left with no model configured.
-
-`npm install` prints a one-line pointer to `cloi setup` and does nothing else:
-no hardware probing, no network, no writes. It is silent under `CI`.
-
-## Usage
-
-```bash
-cloi                          # interactive session in the current folder
-cloi "add tests for auth"     # one-shot request, then exit
-cloi --continue               # resume the last session in this folder
-cloi --session <id>           # resume a specific session
-cloi sessions                 # list recent sessions
-cloi -m qwen3:8b              # use a different model
-```
-
-In a session:
-
-| Command | |
-|---|---|
-| `/help` | command list |
-| `/model [name]` | show or switch model (validates tool support) |
-| `/models` | installed Ollama models |
-| `/tools` | available tools and which ones ask first |
-| `/plan` | current task list |
-| `/usage` | token and throughput breakdown for the last turn |
-| `/sessions` | recent sessions |
-| `/session` | this session's id and workspace |
-| `/exit` | quit |
-
-Ctrl+C interrupts the current turn without killing the session. Ctrl+D exits.
-
-### Output
-
-Startup is two lines. A turn is one line per tool call, results aligned to a
-column so a ten-step turn is scanned rather than read:
-
-```
-  cloi · nemotron-3-nano:4b → qwen3:30b-a3b · 16k
-  ~/my-project · b70f74de · /help
-
-› why is the stats test failing?
+──────────────────────────────────────────────────  nemotron-3-nano:4b
+› why is the empty-list test failing?
 
   ✓ run npm test                                  exit 1
-  ✓ read test/stats.test.js                       13 lines
-  ✓ grep /countByStatus/                          3 matches
-  ✓ read src/lib/store.js                         28 lines
+  ✓ grep /completionRate/                         3 matches
+  ✓ read src/lib/stats.js                         5 lines
 
-  completeTask returns a copy, so the stored task is never marked done.
+  ← Edit src/lib/stats.js
+  1   export function completionRate(tasks) {
+  2 +   if (tasks.length === 0) return 0;
+  3     const done = tasks.filter((t) => t.status === 'done').length;
 
-  ctx 2.7k/16k · 17%
+  ✓ run npm test                                  exit 0
+
+  ctx ███░░░░░░░░░░░░░ 3.5k/16k
 ```
 
-Three rules hold this together:
+## What it does differently
 
-- **A box means something exceptional.** Only a prompt that blocks on you gets
-  one, and its corners are square — rounded borders read as decoration.
-- **One line per event.** A tool call is one line, not a header plus an indented
-  result.
-- **Say it once, and only if it is news.** Setup used to print thirty lines and
-  three boxes before you could type, naming the model six times and announcing
-  good news like "it fits entirely in VRAM". Now it reports only what is
-  actionable, and stays silent when nothing needs deciding.
+Everything below exists because a small local model failed in a specific way
+during live testing. [docs/internals.md](docs/internals.md) has the reasoning.
 
-## Architecture
+### Models chosen by measuring your machine
 
-```
-bin/cloi.js                entry point, preflight checks
-  src/cli/repl.js          chat loop, slash commands, rendering state machine
-  src/agent/
-    loop.js                the agent loop and every safety rail
-    prompt.js              system prompt construction
-    permission.js          approval gating for side-effecting tools
-    verify.js              checks an answer's claims against the files
-    judge.js               reviews claims the filesystem cannot settle
-  src/tools/
-    registry.js            define / validate / dispatch, truncation, name repair
-    fs-tools.js            read, write, edit, list, glob, grep
-    shell.js               run_command
-    todo.js                update_plan
-    workspace.js           path containment, directory walking
-  src/session/store.js     SQLite persistence
-  src/provider/ollama.js   streaming + tool calls over Ollama's HTTP API
-  src/cli/setup.js         hardware detection, model recommendation, downloads
-  src/util/
-    hardware.js            VRAM / RAM / GPU detection
-    recommend.js           model catalog and fit calculation
-    usage.js               token accounting and context pressure
-    secrets.js             credential containment
-    truncate.js            output limits and overflow spill
-```
+Setup reads VRAM, RAM and core count and proposes **two** models against
+different constraints: a primary that fits in VRAM and runs every step, and a
+fallback that only has to fit in RAM because it runs rarely. Then it loads the
+primary and asks Ollama where it actually went, stepping down if the prediction
+was wrong.
 
-### One user turn, many model steps
+Tier means *measured capability*, not size — a 4B model scoring 63% is ranked
+above an 8B scoring 46%. [docs/models.md](docs/models.md)
 
-`runTurn` drives the loop. Each iteration is a **single** model step — the
-provider never loops on tool calls itself. Iteration lives in one place so
-persistence, permissions, and every safety rail sit at the same layer instead of
-being spread across the transport.
+### Escalation when a turn is going wrong
 
-The provider is injectable, so the loop is not bound to Ollama and can be driven
-by a scripted provider under test.
+Six signals say a turn is stuck: repeated identical calls, consecutive tool
+failures, unusable calls, a narrated step never taken. Any of them hands the
+conversation to the bigger model, which inherits everything already tried.
 
-### SQLite is the source of truth
+Routing is on **observed failure**, not on guessing the task type up front.
 
-Conversation state is not an in-memory array that gets flushed to disk. The loop
-rebuilds its model messages from SQLite on **every iteration**, so an
-interrupted turn leaves a coherent, resumable session behind rather than a
-half-written buffer.
+### Answers checked before you see them
 
-### Safety rails
+A claim that a file contains something is settled by the file. Line citations
+are checked against line counts, quotes against what was actually read, and a
+conclusion of absence against how much of the file the agent bothered to open.
+No model call — the workspace already knows.
 
-Small local models fail in specific, repeatable ways. Each has a guard:
+A second, model-based review runs only after an escalation, because that is the
+one moment the answer is worth doubting.
 
-| Failure | Guard |
-|---|---|
-| Invents a tool name (`readFile`, `read-file`) | Levenshtein repair onto the real name; the call proceeds instead of costing a round trip |
-| Repeats an identical failing call | Doom-loop detection — after N identical calls the model is told to change approach |
-| Well-formed calls that all fail | Consecutive-error counter. No strike accrues and nothing repeats, so nothing else sees it |
-| Spins forever | Hard iteration ceiling per turn |
-| Emits unusable calls repeatedly | Strike budget; a tool that ran and reported a real failure does *not* count against it |
-| Returns a huge tool result | Truncated at 2000 lines / 50 KB, overflow spilled to a temp file the agent can read back |
-| Throws inside a tool | `dispatch` never throws; errors return as text the model can act on |
-| Reaches outside the workspace | Every path resolved and contained under the workspace root |
-| Returns nothing at all | Nudged once rather than silently ending the turn |
+### Results you can name and reuse
 
-Every threshold is defaulted inside the loop rather than read straight off
-config. A missing key would otherwise compare against `undefined`, which is
-always false — silently disabling a rail instead of failing loudly.
-
-## Answer verification
-
-Every rail above detects the agent *malfunctioning*. None detects it being
-*wrong* — and in live testing that was the more common failure by a wide margin.
-A model read one line of a twenty-line file, declared the function absent, and
-the loop accepted it: both tool calls had succeeded, nothing repeated, nothing
-looked broken.
-
-Three checks run before an answer is accepted, cheapest first.
-
-### 1. Did the turn leave the workspace changed and broken?
-
-The strongest signal available, and the only one needing no pattern matching and
-no model call — it is pure ordering over the tool log:
-
-- **Still failing** — an edit succeeded, then a command ran *after it* and
-  failed. The change is in place and the thing still does not work.
-- **Unverified** — an edit succeeded, a command had already failed *before* it,
-  and nothing was re-run afterwards.
-
-Both branches are narrow by construction. "Unverified" requires a prior failing
-command, so a turn merely asked to change a file is never scolded for running no
-tests. This is checked first: a workspace left changed and broken is a worse
-outcome than any misworded claim.
-
-### 2. Do the answer's claims survive contact with the files?
-
-No model call — claims about a filesystem are settled by the filesystem.
-
-| Claim in the answer | Check |
-|---|---|
-| Names a file | Does it exist anywhere in the workspace? |
-| Cites `file:line` | Does the file have that many lines? |
-| Asserts something is absent | Grep for it — one match disproves the claim |
-| Quotes source | Does that text appear in a file read, or in tool output? |
-| Concludes absence from a fragment | Was enough of the file actually read? |
-
-A failure is handed back with the specific contradiction — "`completionRate`
-appears in `src/lib/stats.js` at line 16" — and a second failure escalates.
-
-### 3. Does the evidence support the reasoning?
-
-For claims the filesystem cannot settle — a stated root cause, a claimed fix —
-a review pass asks a model whether the gathered evidence actually supports the
-answer. This one costs a call on the largest model on the machine, so it is off
-until the turn has visibly gone wrong.
-
-**It runs only after an escalation.** The primary model failing at this turn is
-the one moment its successor's claim is worth doubting. Reviewing a turn that is
-going fine is a bad trade: a false rejection costs twice, once to hand the right
-answer back and again for the retry. Set `judgeAnswers: true` to review every
-qualifying turn, or `false` to disable it outright.
-
-Once enabled, three gates must all hold:
-
-- the answer **claims** a diagnosis or a fix in so many words — `because` and a
-  bare `fixed` do not count, since this README describes "a fixed
-  `analyze → classify → patch` pipeline" and would otherwise trip its own review
-- the turn **acted** — edited, wrote, or ran something, so there is a claim to check
-- the turn was **demanding** — two or more files changed, ten or more steps, or
-  an escalation. A single edit followed by a passing test is the commonest turn
-  and the easiest to get right; re-reading it buys close to nothing, while
-  cross-file work is where local models actually fail
-
-And regardless of gate, the review **fails open**: an unparseable verdict counts
-as approval, because a verifier that blocks answers when confused is worse than
-none. The judge is the escalation model, since asking the model that just
-produced a wrong answer to grade it mostly reproduces the error.
-
-## Named results
-
-Every tool result the model sees is a preview: truncated to fit the window, and
-eventually dropped by compaction. The full output is filed in the session
-database under a short handle, and the result the model reads ends with it:
+Every substantial result is stored in full under a name taken from its
+arguments — `stats_js`, `grep_completionrate`, `npm_test`:
 
 ```
   ✓ read README.md                                294 of 638 lines
     [saved as readme_md — recall it instead of running this again]
 ```
 
-Handles are named after what they hold, not the order they arrived in:
-`stats_js`, `grep_completionrate`, `npm_test`. `read_1` said which tool ran and
-when, so the model had to fetch a result to remember what was in it. The name is
-also the variable name in the Python kernel, so it has to be a valid identifier
-and must never shadow a tool function — a handle called `grep` would replace the
-tool with a string and break the next cell in a way that looks nothing like the
-cause.
+`recall` reads it back whole, sliced, or searched. The stored copy is complete
+even when what the model was shown was truncated, and it outlives the
+conversation that produced it.
 
-`recall` reads it back — whole, sliced with `start_line`/`end_line`, or searched
-with a pattern. A model that read a 600-line README in six twenty-line calls can
-now read it once and search inside it. `read_file` files the **whole file**, not
-the window it delivered, so a later recall reaches lines that were never sent.
+### Python, with those results already in scope
 
-The idea is [Prime Agent's](https://github.com/PrimeIntellect-ai/prime-agent),
-where results are bound to Python variables in a live kernel and sliced later
-instead of re-read. There is no kernel here, so the store plays that role — and
-it is more durable in one way that matters: a kernel dies with its process,
-whereas a handle named in a summary is still readable after the conversation
-that produced it has been compacted away. The two features are designed to work
-together.
-
-Results over 256 KB are not stored — a runaway command belongs in the overflow
-file, not the session database.
-
-## Python, with results already in scope
-
-`recall` can search a stored result or slice it, and nothing else, because those
-are the two operations written by hand. The `python` tool closes that gap: a
-session-long interpreter where **every stored handle arrives as a variable**.
+A session-long interpreter where every stored result is a variable and **every
+tool is a callable function**:
 
 ```python
-lines = [l for l in read_1.splitlines() if l.startswith('## ')]
-len(lines)
-```
-
-`read_1` was not fetched here. It was bound because an earlier `read_file` call
-produced it, and it holds the whole file, not the window that was shown.
-Variables, imports and functions persist between calls, and a bare expression on
-the last line returns its value the way a notebook does.
-
-This is the part of [Prime Agent's](https://github.com/PrimeIntellect-ai/prime-agent)
-design that made results worth naming — theirs is a live IPython kernel, this is
-a plain interpreter and newline-delimited JSON, which is enough to make a result
-a value you can compute over rather than a lookup you can only re-read.
-
-Tools are callable too, so a cell can drive a loop of them for one model
-round-trip instead of one per file:
-
-```python
-hits = grep(pattern='completionRate')
-files = sorted({l.split(':')[0] for l in hits.splitlines()[1:]})
+files = glob(pattern='src/**/*.js').splitlines()[1:]
 sizes = {f: len(read_file(path=f)) for f in files}
+sorted(sizes.items(), key=lambda kv: -kv[1])[:3]
 ```
 
-Each call blocks the cell until the host answers, so it reads exactly like the
-function it appears to be. A tool that fails raises `ToolError`, which the code
-around it can catch and act on.
+One cell drives a loop that would otherwise be one tool call per turn. Variables,
+imports and helper functions survive across sessions. Tools that ask permission
+still ask, so approving a cell does not approve everything it can reach.
 
-**Approving the scratchpad does not approve what the scratchpad can reach.** A
-tool that normally asks permission still asks when it is called from Python —
-otherwise an approved cell would be a way to edit files and run shell commands
-with no prompt at all, which is the gate the model would be routing around.
-
-### Does telling the model help?
-
-`bench/python-tool.js` measures it, because the answer was not obvious. The tool
-description carries three worked cells; the benchmark runs the same task with
-and without them, on a fixture where exports and file length vary independently
-so that the densest file is not the one with the most exports — no single tool
-call gets there.
+Measured on `nemotron-3-nano:4b`, 8 runs per arm, on a task needing per-file
+arithmetic:
 
 ```
-model      nemotron-3-nano:4b        8 repeats per arm
-
 arm               correct   used python   calls   time
 without examples  0/8       0/8           7.1     9s
 with examples     3/8       8/8           3.8     6s
 ```
 
-Tool selection is the decisive change: never reached for, to always reached for,
-at roughly half the tool calls. Accuracy moves from never right to sometimes
-right — the surviving failures are ordinary Python bugs, a different one each
-run, which is what a 4B model writing code looks like rather than a missing
-instruction.
+### History summarised, not silently dropped
 
-A fourth note, explaining that `glob` output begins with a summary line, was
-tried against the commonest error and made no measurable difference. It was
-removed rather than kept on the strength of the theory.
+Ollama does not refuse an over-long prompt — it drops the oldest tokens, so the
+agent forgets what it was asked while behaving as though it remembers. Cloi
+summarises the older half instead, cutting only where a tool result cannot be
+separated from the call that produced it.
 
-```bash
-node bench/python-tool.js --repeats 8 qwen3:8b
-```
+Nothing is deleted: the summary records how far it reaches, and older messages
+are simply not sent.
 
-It is **additive**, and that is deliberate. The ordinary tools remain and the
-model is free to ignore Python entirely, because writing correct code against
-live state is harder than emitting a tool call — and a bad line here can leave a
-namespace that later cells inherit. The tool asks permission like `run_command`,
-runs with the same sanitised environment so a cell cannot read your API keys,
-and is not offered at all when no interpreter is present.
+### Guardrails around what it can touch
 
-Detection runs the interpreter rather than trusting the name: on Windows
-`python3` is frequently an App Execution Alias that prints "Python was not
-found" and **exits 0**, so a `which`-style check reports success and the kernel
-then fails at the first cell with nothing to explain it.
+Paths are contained to the workspace. Writes, edits and shell commands ask
+first, with three answers — once, always-for-this-tool, or no. Subprocesses run
+with a sanitised environment, so a command cannot read your API keys, and any
+secret that reaches output is redacted before it is stored or sent.
 
-The namespace is **saved between runs**, so resuming a session brings back the
-variables, imports and helpers from the last one:
-
-```
-[restored from the last session: counts, json, pattern, rate, re]
-```
-
-Saved per variable rather than all at once, so one open file handle cannot take
-everything else with it — what could not be saved is named. Two things pickle
-cannot store are handled specially, because they are the commonest things a
-namespace holds: a **module** is recorded by name and imported again, and a
-**function or class** defined in a cell is saved as its source and replayed. A
-name later rebound to a value is restored as that value, not resurrected as the
-old function.
-
-The write is atomic, and a corrupt or missing snapshot is not an error — the
-kernel starts empty and says so, because losing variables is a nuisance while
-refusing to start is a broken session.
-
-A cell that does not finish within 30 seconds is killed. The kernel is
-single-threaded, so one hung cell would otherwise block every cell after it —
-and the loss of the namespace is reported rather than left to be discovered.
-
-## Compaction
-
-A long session eventually sends more history than the model can hold. Ollama
-does not refuse — it silently drops the oldest tokens, which is the worst
-available failure: the agent forgets what it was asked while behaving as though
-it remembers. When a request comes within `compactionReserveTokens` of the
-window, the older half is replaced by a written summary.
-
-The hard part is *where* to cut, and the approach is taken from
-[Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent), which is
-careful about two cases that produce an unreadable message list:
-
-- **Never cut at a tool result.** It belongs to the assistant message that
-  requested it. Separated, the model sees output for a call it never made.
-- **A cut inside a turn carries that turn's question with it.** Otherwise the
-  kept history opens with an answer to a question that is gone, and the model
-  defends it rather than revisiting it.
-
-Two things differ from theirs. The trigger uses the prompt size Ollama actually
-reported rather than an estimate — a measured number for the one decision that
-matters. And **nothing is deleted**: the compaction records how far the summary
-reaches, and older rows are simply not sent. The transcript on disk stays whole,
-so a bad summary costs context rather than history, and the session can still be
-read back in full.
-
-Failure is silent by design. A summariser that errors, returns nothing, or finds
-no safe cut leaves the history exactly as it was — merely large. Taking the turn
-down to avoid a large prompt would be a poor trade.
-
-### Biased toward silence
-
-A false accusation costs a wasted round trip and teaches you to ignore the
-check, so a claim is reported only when it can be positively *disproved*. Prose
-with nothing checkable in it passes untouched.
-
-That bias was earned. Live testing produced three false positives, each now
-covered by a regression test: a file referred to by bare name was called
-nonexistent; an odd number of backticks made the quote checker capture prose
-*between* two code spans; and a value quoted out of `npm test` output was
-reported as fabrication because the check searched only file contents.
-
-## Model escalation
-
-A model that gets stuck can hand the turn to a stronger one. Set
-`escalationModel`; the replacement inherits the full conversation plus a note
-explaining why it was brought in, so it can see exactly what was already tried.
-
-Routing is on **observed failure, not predicted task type**. The loop already
-knows when it is struggling; classifying a task up front would cost a model call
-to guess something the loop can simply measure.
-
-Six triggers, in the order live testing showed they were needed:
-
-| Trigger | Detects |
-|---|---|
-| Strike budget exhausted | Unknown tool names, unusable arguments |
-| Doom loop | The same call repeated verbatim |
-| Consecutive tool errors | Well-formed calls that all fail — wrong paths, wrong flags |
-| Repeated surrender | Narrated a next step and stopped, after a nudge already failed |
-| Claim disproved | Verification found a statement the files contradict |
-| Evidence insufficient | The review pass rejected the reasoning |
-
-The last three exist because the first three caught roughly two failures in
-five. Weak models rarely break mechanically; they narrate a next step and stop,
-or answer confidently and wrongly.
-
-Phrase matching catches some narration, but every run turned up a new phrasing,
-so the durable signal is phrasing-independent: **tools were tried, none
-succeeded, and the model stopped anyway**.
-
-A cheap nudge is always tried before escalating, and the escalated model gets
-its own nudge budget rather than inheriting an exhausted one.
-
-### What a switch actually does
-
-```
-escalations++                 currentModel = escalationModel
-callCounts.clear()            strikes = 0
-consecutiveToolErrors = 0     surrenders = 0
-verificationFailures = 0
-```
-
-Every counter resets, because the new model should not be blamed for the
-previous one's mistakes. A handoff note is appended to the conversation, and the
-loop continues — same session, same history, rebuilt from SQLite.
-
-**Cost on a small card.** Swapping takes ~3–8 s, and switching forfeits the KV
-cache, so the conversation is reprocessed. On 8 GB only one model stays resident
-— `qwen3:1.7b` alone occupies 3.2 GB of VRAM, well above its 1.4 GB on disk.
-That is affordable precisely because escalation is rare and capped; it is not a
-mechanism for routing every turn.
-
-## Permissions
-
-`write_file`, `edit_file`, and `run_command` ask before running. Three answers,
-because two are not enough: **once**, **always for this tool**, or **no**.
-"Always" is scoped to the running process — a statement about this session, not
-a standing grant that silently persists into future runs. Add tool names to
-`autoApprove` for a durable grant.
-
-## Credential containment
-
-The agent can run shell commands and write files, so anything reachable from its
-environment is one `echo` away from being exfiltrated. Two layers:
-
-1. **Secrets are stripped from child processes.** `run_command` spawns with a
-   sanitised environment — anything matching a credential-shaped name
-   (`*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, …) plus an explicit list of
-   known provider variables. `SSH_AUTH_SOCK`, `XAUTHORITY` and friends are
-   exempted, because removing them breaks `git push` for no security gain.
-2. **Live secret values are redacted from tool output.** Only values actually
-   present in the environment are masked, so redaction is precise. This catches
-   a credential arriving by another route — a `.env` file, a config dump, a
-   verbose log — before it reaches the transcript or a provider.
-
-Identifiers are deliberately *not* treated as credentials. Redaction matches on
-value, so classifying a session id as secret corrupted a real file path into
-`.../[redacted]/...` when that id was also a directory name.
-
-This is defence in depth, not a guarantee: an agent running arbitrary commands
-can still read a credentials file off disk. It removes the trivial paths.
-
-## Cross-platform by construction
-
-No shelling out to `sed`, `cat`, `find`, `which`, or `patch`. Filesystem work
-uses Node APIs and `fs.globSync`, so behaviour is identical on Windows and
-POSIX. The only shell is `run_command`, and the system prompt tells the model
-which shell it is actually talking to.
-
-## Configuration
-
-`~/.cloi/config.json` (override the location with `CLOI_DATA_DIR`):
-
-```json
-{
-  "model": "qwen3:8b",
-  "host": "http://127.0.0.1:11434",
-
-  "maxIterations": 40,
-  "maxStrikes": 3,
-  "doomLoopThreshold": 3,
-  "maxConsecutiveToolErrors": 3,
-
-  "escalationModel": null,
-  "maxEscalations": 1,
-
-  "verifyAnswers": true,
-  "maxVerificationRetries": 1,
-  "judgeAnswers": null,
-  "judgeModel": null,
-
-  "temperature": 0.2,
-  "think": null,
-  "contextLength": 16384,
-  "compaction": true,
-  "compactionReserveTokens": 2048,
-  "showUsage": true,
-  "autoApprove": []
-}
-```
-
-`think` is off by default: on local hardware a visible reasoning pass costs a
-great deal of latency and buys little accuracy for tool selection. Turning it
-off took one measured task from ~106 s to ~16 tok/s sustained.
-
-Keep `maxVerificationRetries` low. A model that fails the same complaint twice
-will fail it five times — measured, not assumed.
-
-## Performance and usage reporting
-
-This runs local models, and it feels like it. On a laptop with 8 GB of VRAM,
-`gemma4:12b` sits around 67% GPU / 33% CPU and a turn with a few tool calls
-takes minutes rather than seconds.
-
-Every turn ends with one number:
-
-```
-  ctx 1.3k/16k · 8%
-```
-
-Context is the only stat that is *news*. Throughput, time-to-first-token and
-elapsed time are constants of your hardware — you learn them once. Context
-climbs across a session and has a cliff: exceed `contextLength` and Ollama
-silently drops history, so the agent quietly forgets a file it read three turns
-ago, with no error anywhere. The line is dim below 70%, yellow at 70%, and red
-at 90% with an explanation.
-
-`/usage` expands to the full breakdown — input/output tokens, generation rate,
-prompt-eval rate, TTFT, model load, and the split between model time and time
-spent in tools. The numbers come from Ollama's own counters, not estimates, and
-two are computed deliberately:
-
-- **tok/s is measured against the model's eval duration**, not wall clock, so it
-  reports real throughput and is not dragged down by time in tools or a
-  cold-start load.
-- **ctx is a high-water mark, not a sum.** Each step resends the conversation,
-  so summing prompt tokens would imply the window was blown when it was not.
-
-## What live testing showed
-
-The rails above are not speculative — each was added after watching a specific
-failure, and several were built the wrong way first.
-
-**Escalation works, and raises the floor rather than the ceiling.** A weak
-primary handing off to a stronger model was demonstrated repeatedly; after
-handoff the stronger model traced a failure across files the weak one never
-approached. But no amount of rescue makes a task solvable that no available
-model can solve.
-
-**Malfunction is the minority failure.** Across five live runs, mechanical rails
-fired on two. The other three were confident and wrong, with every tool call
-succeeding — which is why verification exists.
-
-**Verification changes outcomes.** Replaying the exact turn that failed before:
-the model read one line, claimed absence, was told its evidence was thin,
-re-read the whole file and answered correctly — *without* escalating. The weak
-model could do the task all along; it needed to be told its evidence was thin.
-
-**Detection is not capability.** A cross-file bug — the failing test names one
-module, the cause lives in another — was attempted four times by `qwen3:8b`,
-with and without every rail. It never solved it, and a control run with all
-rails off failed identically. The checks made the failure *loud* instead of
-silent, which is the real win: without them the run ended with a nonsense edit
-in place and a confident summary.
-
-**Context growth is the cost driver.** A trivial four-step turn consumed 6.5k
-input tokens, because each step resends the whole conversation plus ~4 KB of
-tool schemas. Free on Ollama, expensive on a metered API.
-
-## Tests
+## Usage
 
 ```bash
-npm test
+cloi                        # interactive session
+cloi "add tests for auth"   # one request, then exit
+cloi --continue             # resume the last session here
+cloi setup                  # re-pick models
 ```
 
-126 tests covering tool-name repair, argument validation and coercion, dispatch
-error containment, availability probes, output truncation and overflow recovery,
-workspace path containment, call-identity hashing, permission gating,
-credential containment, usage accounting, escalation triggers and handoff state,
-model recommendation across hardware profiles, and every verification check —
-including regression tests for each false positive found in live runs.
+In a session: `/model`, `/tools`, `/plan`, `/usage`, `/sessions`, `/help`.
+Ctrl+C interrupts a turn; Ctrl+D exits.
+
+## Documentation
+
+- [docs/models.md](docs/models.md) — how models are chosen, and the benchmark behind the catalog
+- [docs/internals.md](docs/internals.md) — the loop, the rails, verification, and what live testing changed
+- [docs/configuration.md](docs/configuration.md) — every setting and its default
+
+## Benchmarks
+
+```bash
+node bench/compare.js qwen3:8b nemotron-3-nano:4b   # models, inside this loop
+node bench/python-tool.js --repeats 8               # does documenting a tool change its use?
+```
+
+Both drive the real agent against the real tools, because what matters is how a
+model behaves *here*, not on a leaderboard with different tools and prompts.
 
 ## Known gaps
 
-- **Ollama only.** No cloud provider or bring-your-own-key yet. A generic
-  OpenAI-compatible provider would unlock Kimi, OpenRouter, Groq, and local vLLM
-  through one code path.
-- **No context compaction.** Full history is resent every iteration.
-- **No sub-agents, MCP, web access, or retrieval.**
-- **The interactive permission prompt has not been exercised with a live
-  keypress.** Its logic has unit coverage; the readline round trip does not.
-- **Tested against `gemma4:12b`, `qwen3:8b`, and `qwen3:1.7b`.**
+- Only Ollama. The provider sits behind one module, but nothing else is wired up.
+- No sub-agents, no MCP, no web access.
+- Hard cross-file debugging is above the ceiling of every model that fits 8 GB — 0/12 in the benchmark, and that is the honest limit.
 
 ## License
 
-MIT
+MIT. See [LICENSE](LICENSE).

--- a/bench/python-tool.js
+++ b/bench/python-tool.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Does documenting the Python tool change how a model uses it?
+ *
+ * The `python` tool exposes a persistent interpreter where stored results are
+ * variables and every other tool is a callable function. None of that is
+ * discoverable: a model that is not told cannot guess it. This measures the
+ * cost of *not* saying so, by running the same task twice with the only
+ * difference being whether the tool description carries worked examples.
+ *
+ * The task has to be one where the kernel genuinely wins, which is harder to
+ * arrange than it sounds. The first version asked for a total count of
+ * `export function` across a directory — but grep reports a match count, so it
+ * answered in a single call and the baseline scored 3/3 without ever touching
+ * Python. The fixture here varies exports and file length *independently*, so
+ * the file with the highest exports-per-line is not the file with the most
+ * exports, and no single tool call gets there.
+ *
+ * Usage:
+ *   node bench/python-tool.js                         # default model, 8 repeats
+ *   node bench/python-tool.js --repeats 12 qwen3:8b
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRegistry } from '../src/tools/index.js';
+import { PermissionManager } from '../src/agent/permission.js';
+import { runTurn } from '../src/agent/loop.js';
+import { loadConfig } from '../src/config.js';
+import { Session } from '../src/session/store.js';
+import { shutdownKernels, detectPython } from '../src/tools/kernel.js';
+
+/**
+ * Exports and total length vary independently.
+ *
+ * `golf` has the most exported functions; `hotel` has the highest ratio. A
+ * model that tallies grep output and stops has the wrong answer, so reaching
+ * the right one takes either a read of every file or a single cell.
+ */
+const FILES = [
+  ['alpha', 4, 40], ['bravo', 2, 8], ['charlie', 5, 60], ['delta', 1, 30],
+  ['echo', 3, 12], ['foxtrot', 2, 50], ['golf', 6, 90], ['hotel', 3, 9],
+];
+
+const TASK = 'For each file in src/, work out how many `export function` declarations it has '
+  + 'divided by its total number of lines. Reply with just the filename that has the highest ratio.';
+
+/** The file with the highest exports-per-line, computed rather than asserted. */
+const ANSWER = FILES.reduce((best, f) => (f[1] / f[2] > best[1] / best[2] ? f : best))[0];
+
+function makeWorkspace() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloi-pybench-'));
+  fs.mkdirSync(path.join(dir, 'src'));
+  fs.writeFileSync(path.join(dir, 'package.json'), '{ "name": "pybench" }\n');
+
+  for (const [name, exports, lines] of FILES) {
+    const body = [
+      ...Array.from({ length: exports }, (_, i) => `export function ${name}_${i + 1}() { return ${i + 1}; }`),
+      ...Array.from({ length: lines - exports }, (_, i) => `// padding line ${i + 1}`),
+    ];
+    fs.writeFileSync(path.join(dir, 'src', `${name}.js`), `${body.join('\n')}\n`);
+  }
+  return dir;
+}
+
+/** The registry, with the worked examples optionally stripped back out. */
+function registryFor({ examples }) {
+  const registry = createRegistry();
+  if (!examples) {
+    const tool = registry.get('python');
+    const cut = tool.description.indexOf('\nExamples:');
+    if (cut !== -1) tool.description = tool.description.slice(0, cut);
+  }
+  return registry;
+}
+
+async function runOnce({ model, cwd, examples, maxIterations }) {
+  const registry = registryFor({ examples });
+  const session = Session.create({ cwd, model });
+  const calls = [];
+  const errors = [];
+  const started = Date.now();
+
+  const result = await runTurn({
+    session,
+    registry,
+    permissions: new PermissionManager({ ask: async () => 'allow' }),
+    config: {
+      model, contextLength: 16384, maxIterations, escalationModel: null,
+      // Both arms measure tool choice, not the rails. Verification and review
+      // would add model calls that differ between arms for reasons unrelated
+      // to the question being asked.
+      verifyAnswers: false, judgeAnswers: false, compaction: true,
+    },
+    ui: {
+      onToolStart: ({ name }) => calls.push(name),
+      onToolEnd: ({ name, result: r }) => {
+        if (name === 'python' && r.isError) errors.push(r.output.split('\n').pop().slice(0, 70));
+      },
+    },
+    userText: TASK,
+  });
+
+  const text = result.text || '';
+  return {
+    correct: new RegExp(`\\b${ANSWER}\\b`, 'i').test(text),
+    usedPython: calls.includes('python'),
+    calls: calls.length,
+    seconds: (Date.now() - started) / 1000,
+    errors,
+  };
+}
+
+function summarise(label, runs) {
+  const n = runs.length;
+  const rate = (pick) => `${runs.filter(pick).length}/${n}`;
+  const mean = (pick) => (runs.reduce((s, r) => s + pick(r), 0) / n).toFixed(1);
+  return {
+    label,
+    correct: rate((r) => r.correct),
+    usedPython: rate((r) => r.usedPython),
+    calls: mean((r) => r.calls),
+    seconds: `${mean((r) => r.seconds)}s`,
+    cellErrors: runs.reduce((s, r) => s + r.errors.length, 0),
+  };
+}
+
+function parseArgs(argv) {
+  const opts = { repeats: 8, model: null, maxIterations: 25 };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--repeats' || argv[i] === '-n') opts.repeats = Number(argv[++i]);
+    else if (argv[i] === '--max-iterations') opts.maxIterations = Number(argv[++i]);
+    else if (!argv[i].startsWith('-')) opts.model = argv[i];
+  }
+  return opts;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const model = opts.model || loadConfig().model;
+
+  if (!detectPython()) {
+    console.error('No Python 3 interpreter found, so the tool under test is not offered. Nothing to measure.');
+    return 1;
+  }
+
+  const cwd = makeWorkspace();
+  console.log(`model      ${model}`);
+  console.log(`task       ${TASK}`);
+  console.log(`answer     ${ANSWER}.js  (most exports is ${FILES.reduce((b, f) => (f[1] > b[1] ? f : b))[0]}.js — a tally gets it wrong)`);
+  console.log(`repeats    ${opts.repeats} per arm\n`);
+
+  const arms = [];
+  for (const examples of [false, true]) {
+    const label = examples ? 'with examples' : 'without examples';
+    const runs = [];
+    for (let i = 0; i < opts.repeats; i++) {
+      process.stdout.write(`  ${label}: run ${i + 1}/${opts.repeats}\r`);
+      runs.push(await runOnce({ model, cwd, examples, maxIterations: opts.maxIterations }));
+    }
+    process.stdout.write(' '.repeat(40) + '\r');
+    arms.push(summarise(label, runs));
+
+    const failures = runs.flatMap((r) => r.errors);
+    if (failures.length) {
+      const counts = new Map();
+      for (const f of failures) counts.set(f, (counts.get(f) || 0) + 1);
+      arms.at(-1).topError = [...counts].sort((a, b) => b[1] - a[1])[0];
+    }
+  }
+
+  console.log(`${'arm'.padEnd(18)}${'correct'.padEnd(10)}${'used python'.padEnd(14)}${'calls'.padEnd(8)}time`);
+  for (const arm of arms) {
+    console.log(
+      arm.label.padEnd(18) + arm.correct.padEnd(10) + arm.usedPython.padEnd(14)
+      + arm.calls.padEnd(8) + arm.seconds,
+    );
+  }
+
+  for (const arm of arms) {
+    if (arm.cellErrors) {
+      console.log(`\n${arm.label}: ${arm.cellErrors} cells raised. Commonest: ${arm.topError?.[0]} (×${arm.topError?.[1]})`);
+    }
+  }
+
+  shutdownKernels();
+  // The interpreter ran with the fixture as its working directory and holds it
+  // for a moment after being killed. Tidying up is not worth throwing away a
+  // measurement that took minutes to produce.
+  try {
+    fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 20, retryDelay: 150 });
+  } catch {
+    console.log(`\n(left ${cwd} behind; the interpreter still held it)`);
+  }
+  return 0;
+}
+
+main().then((code) => { process.exitCode = code ?? 0; });

--- a/bin/cloi.js
+++ b/bin/cloi.js
@@ -28,6 +28,7 @@ import { runSetup } from '../src/cli/setup.js';
 import * as ollama from '../src/provider/ollama.js';
 import { pruneOverflow, CONFIG_PATH } from '../src/util/paths.js';
 import { closeReadline } from '../src/ui/terminal.js';
+import { shutdownKernels } from '../src/tools/kernel.js';
 
 const USAGE = `
 ${chalk.hex('#7aa2f7').bold('cloi')} — local coding agent powered by Ollama
@@ -208,6 +209,9 @@ async function main() {
  */
 function finish(code) {
   process.exitCode = code ?? 0;
+  // The Python kernel is a child process; without this it outlives the session
+  // that started it and keeps the workspace directory open.
+  shutdownKernels();
   // Nothing is left to read, and an un-unref'd stdin would keep the loop alive.
   process.stdin.pause();
   process.stdin.unref?.();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,42 @@
+# Configuration
+
+Every setting, what it defaults to, and why.
+
+## Configuration
+
+`~/.cloi/config.json` (override the location with `CLOI_DATA_DIR`):
+
+```json
+{
+  "model": "qwen3:8b",
+  "host": "http://127.0.0.1:11434",
+
+  "maxIterations": 40,
+  "maxStrikes": 3,
+  "doomLoopThreshold": 3,
+  "maxConsecutiveToolErrors": 3,
+
+  "escalationModel": null,
+  "maxEscalations": 1,
+
+  "verifyAnswers": true,
+  "maxVerificationRetries": 1,
+  "judgeAnswers": null,
+  "judgeModel": null,
+
+  "temperature": 0.2,
+  "think": null,
+  "contextLength": 16384,
+  "compaction": true,
+  "compactionReserveTokens": 2048,
+  "showUsage": true,
+  "autoApprove": []
+}
+```
+
+`think` is off by default: on local hardware a visible reasoning pass costs a
+great deal of latency and buys little accuracy for tool selection. Turning it
+off took one measured task from ~106 s to ~16 tok/s sustained.
+
+Keep `maxVerificationRetries` low. A model that fails the same complaint twice
+will fail it five times — measured, not assumed.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,0 +1,481 @@
+# How it works
+
+The design decisions behind the agent loop, and what live testing changed about them.
+The README shows what cloi does; this explains why it is built this way.
+
+## Architecture
+
+```
+bin/cloi.js                entry point, preflight checks
+  src/cli/repl.js          chat loop, slash commands, rendering state machine
+  src/agent/
+    loop.js                the agent loop and every safety rail
+    prompt.js              system prompt construction
+    permission.js          approval gating for side-effecting tools
+    verify.js              checks an answer's claims against the files
+    judge.js               reviews claims the filesystem cannot settle
+  src/tools/
+    registry.js            define / validate / dispatch, truncation, name repair
+    fs-tools.js            read, write, edit, list, glob, grep
+    shell.js               run_command
+    todo.js                update_plan
+    workspace.js           path containment, directory walking
+  src/session/store.js     SQLite persistence
+  src/provider/ollama.js   streaming + tool calls over Ollama's HTTP API
+  src/cli/setup.js         hardware detection, model recommendation, downloads
+  src/util/
+    hardware.js            VRAM / RAM / GPU detection
+    recommend.js           model catalog and fit calculation
+    usage.js               token accounting and context pressure
+    secrets.js             credential containment
+    truncate.js            output limits and overflow spill
+```
+
+### One user turn, many model steps
+
+`runTurn` drives the loop. Each iteration is a **single** model step — the
+provider never loops on tool calls itself. Iteration lives in one place so
+persistence, permissions, and every safety rail sit at the same layer instead of
+being spread across the transport.
+
+The provider is injectable, so the loop is not bound to Ollama and can be driven
+by a scripted provider under test.
+
+### SQLite is the source of truth
+
+Conversation state is not an in-memory array that gets flushed to disk. The loop
+rebuilds its model messages from SQLite on **every iteration**, so an
+interrupted turn leaves a coherent, resumable session behind rather than a
+half-written buffer.
+
+### Safety rails
+
+Small local models fail in specific, repeatable ways. Each has a guard:
+
+| Failure | Guard |
+|---|---|
+| Invents a tool name (`readFile`, `read-file`) | Levenshtein repair onto the real name; the call proceeds instead of costing a round trip |
+| Repeats an identical failing call | Doom-loop detection — after N identical calls the model is told to change approach |
+| Well-formed calls that all fail | Consecutive-error counter. No strike accrues and nothing repeats, so nothing else sees it |
+| Spins forever | Hard iteration ceiling per turn |
+| Emits unusable calls repeatedly | Strike budget; a tool that ran and reported a real failure does *not* count against it |
+| Returns a huge tool result | Truncated at 2000 lines / 50 KB, overflow spilled to a temp file the agent can read back |
+| Throws inside a tool | `dispatch` never throws; errors return as text the model can act on |
+| Reaches outside the workspace | Every path resolved and contained under the workspace root |
+| Returns nothing at all | Nudged once rather than silently ending the turn |
+
+Every threshold is defaulted inside the loop rather than read straight off
+config. A missing key would otherwise compare against `undefined`, which is
+always false — silently disabling a rail instead of failing loudly.
+
+## Answer verification
+
+Every rail above detects the agent *malfunctioning*. None detects it being
+*wrong* — and in live testing that was the more common failure by a wide margin.
+A model read one line of a twenty-line file, declared the function absent, and
+the loop accepted it: both tool calls had succeeded, nothing repeated, nothing
+looked broken.
+
+Three checks run before an answer is accepted, cheapest first.
+
+### 1. Did the turn leave the workspace changed and broken?
+
+The strongest signal available, and the only one needing no pattern matching and
+no model call — it is pure ordering over the tool log:
+
+- **Still failing** — an edit succeeded, then a command ran *after it* and
+  failed. The change is in place and the thing still does not work.
+- **Unverified** — an edit succeeded, a command had already failed *before* it,
+  and nothing was re-run afterwards.
+
+Both branches are narrow by construction. "Unverified" requires a prior failing
+command, so a turn merely asked to change a file is never scolded for running no
+tests. This is checked first: a workspace left changed and broken is a worse
+outcome than any misworded claim.
+
+### 2. Do the answer's claims survive contact with the files?
+
+No model call — claims about a filesystem are settled by the filesystem.
+
+| Claim in the answer | Check |
+|---|---|
+| Names a file | Does it exist anywhere in the workspace? |
+| Cites `file:line` | Does the file have that many lines? |
+| Asserts something is absent | Grep for it — one match disproves the claim |
+| Quotes source | Does that text appear in a file read, or in tool output? |
+| Concludes absence from a fragment | Was enough of the file actually read? |
+
+A failure is handed back with the specific contradiction — "`completionRate`
+appears in `src/lib/stats.js` at line 16" — and a second failure escalates.
+
+### 3. Does the evidence support the reasoning?
+
+For claims the filesystem cannot settle — a stated root cause, a claimed fix —
+a review pass asks a model whether the gathered evidence actually supports the
+answer. This one costs a call on the largest model on the machine, so it is off
+until the turn has visibly gone wrong.
+
+**It runs only after an escalation.** The primary model failing at this turn is
+the one moment its successor's claim is worth doubting. Reviewing a turn that is
+going fine is a bad trade: a false rejection costs twice, once to hand the right
+answer back and again for the retry. Set `judgeAnswers: true` to review every
+qualifying turn, or `false` to disable it outright.
+
+Once enabled, three gates must all hold:
+
+- the answer **claims** a diagnosis or a fix in so many words — `because` and a
+  bare `fixed` do not count, since cloi's own history describes "a fixed
+  `analyze → classify → patch` pipeline" and prose like that would otherwise
+  trip its own review
+- the turn **acted** — edited, wrote, or ran something, so there is a claim to check
+- the turn was **demanding** — two or more files changed, ten or more steps, or
+  an escalation. A single edit followed by a passing test is the commonest turn
+  and the easiest to get right; re-reading it buys close to nothing, while
+  cross-file work is where local models actually fail
+
+And regardless of gate, the review **fails open**: an unparseable verdict counts
+as approval, because a verifier that blocks answers when confused is worse than
+none. The judge is the escalation model, since asking the model that just
+produced a wrong answer to grade it mostly reproduces the error.
+
+## Model escalation
+
+A model that gets stuck can hand the turn to a stronger one. Set
+`escalationModel`; the replacement inherits the full conversation plus a note
+explaining why it was brought in, so it can see exactly what was already tried.
+
+Routing is on **observed failure, not predicted task type**. The loop already
+knows when it is struggling; classifying a task up front would cost a model call
+to guess something the loop can simply measure.
+
+Six triggers, in the order live testing showed they were needed:
+
+| Trigger | Detects |
+|---|---|
+| Strike budget exhausted | Unknown tool names, unusable arguments |
+| Doom loop | The same call repeated verbatim |
+| Consecutive tool errors | Well-formed calls that all fail — wrong paths, wrong flags |
+| Repeated surrender | Narrated a next step and stopped, after a nudge already failed |
+| Claim disproved | Verification found a statement the files contradict |
+| Evidence insufficient | The review pass rejected the reasoning |
+
+The last three exist because the first three caught roughly two failures in
+five. Weak models rarely break mechanically; they narrate a next step and stop,
+or answer confidently and wrongly.
+
+Phrase matching catches some narration, but every run turned up a new phrasing,
+so the durable signal is phrasing-independent: **tools were tried, none
+succeeded, and the model stopped anyway**.
+
+A cheap nudge is always tried before escalating, and the escalated model gets
+its own nudge budget rather than inheriting an exhausted one.
+
+### What a switch actually does
+
+```
+escalations++                 currentModel = escalationModel
+callCounts.clear()            strikes = 0
+consecutiveToolErrors = 0     surrenders = 0
+verificationFailures = 0
+```
+
+Every counter resets, because the new model should not be blamed for the
+previous one's mistakes. A handoff note is appended to the conversation, and the
+loop continues — same session, same history, rebuilt from SQLite.
+
+**Cost on a small card.** Swapping takes ~3–8 s, and switching forfeits the KV
+cache, so the conversation is reprocessed. On 8 GB only one model stays resident
+— `qwen3:1.7b` alone occupies 3.2 GB of VRAM, well above its 1.4 GB on disk.
+That is affordable precisely because escalation is rare and capped; it is not a
+mechanism for routing every turn.
+
+## Compaction
+
+A long session eventually sends more history than the model can hold. Ollama
+does not refuse — it silently drops the oldest tokens, which is the worst
+available failure: the agent forgets what it was asked while behaving as though
+it remembers. When a request comes within `compactionReserveTokens` of the
+window, the older half is replaced by a written summary.
+
+The hard part is *where* to cut, and the approach is taken from
+[Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent), which is
+careful about two cases that produce an unreadable message list:
+
+- **Never cut at a tool result.** It belongs to the assistant message that
+  requested it. Separated, the model sees output for a call it never made.
+- **A cut inside a turn carries that turn's question with it.** Otherwise the
+  kept history opens with an answer to a question that is gone, and the model
+  defends it rather than revisiting it.
+
+Two things differ from theirs. The trigger uses the prompt size Ollama actually
+reported rather than an estimate — a measured number for the one decision that
+matters. And **nothing is deleted**: the compaction records how far the summary
+reaches, and older rows are simply not sent. The transcript on disk stays whole,
+so a bad summary costs context rather than history, and the session can still be
+read back in full.
+
+Failure is silent by design. A summariser that errors, returns nothing, or finds
+no safe cut leaves the history exactly as it was — merely large. Taking the turn
+down to avoid a large prompt would be a poor trade.
+
+### Biased toward silence
+
+A false accusation costs a wasted round trip and teaches you to ignore the
+check, so a claim is reported only when it can be positively *disproved*. Prose
+with nothing checkable in it passes untouched.
+
+That bias was earned. Live testing produced three false positives, each now
+covered by a regression test: a file referred to by bare name was called
+nonexistent; an odd number of backticks made the quote checker capture prose
+*between* two code spans; and a value quoted out of `npm test` output was
+reported as fabrication because the check searched only file contents.
+
+## Named results
+
+Every tool result the model sees is a preview: truncated to fit the window, and
+eventually dropped by compaction. The full output is filed in the session
+database under a short handle, and the result the model reads ends with it:
+
+```
+  ✓ read README.md                                294 of 638 lines
+    [saved as readme_md — recall it instead of running this again]
+```
+
+Handles are named after what they hold, not the order they arrived in:
+`stats_js`, `grep_completionrate`, `npm_test`. `read_1` said which tool ran and
+when, so the model had to fetch a result to remember what was in it. The name is
+also the variable name in the Python kernel, so it has to be a valid identifier
+and must never shadow a tool function — a handle called `grep` would replace the
+tool with a string and break the next cell in a way that looks nothing like the
+cause.
+
+`recall` reads it back — whole, sliced with `start_line`/`end_line`, or searched
+with a pattern. A model that read a 600-line README in six twenty-line calls can
+now read it once and search inside it. `read_file` files the **whole file**, not
+the window it delivered, so a later recall reaches lines that were never sent.
+
+The idea is [Prime Agent's](https://github.com/PrimeIntellect-ai/prime-agent),
+where results are bound to Python variables in a live kernel and sliced later
+instead of re-read. There is no kernel here, so the store plays that role — and
+it is more durable in one way that matters: a kernel dies with its process,
+whereas a handle named in a summary is still readable after the conversation
+that produced it has been compacted away. The two features are designed to work
+together.
+
+Results over 256 KB are not stored — a runaway command belongs in the overflow
+file, not the session database.
+
+## Python, with results already in scope
+
+`recall` can search a stored result or slice it, and nothing else, because those
+are the two operations written by hand. The `python` tool closes that gap: a
+session-long interpreter where **every stored handle arrives as a variable**.
+
+```python
+lines = [l for l in read_1.splitlines() if l.startswith('## ')]
+len(lines)
+```
+
+`read_1` was not fetched here. It was bound because an earlier `read_file` call
+produced it, and it holds the whole file, not the window that was shown.
+Variables, imports and functions persist between calls, and a bare expression on
+the last line returns its value the way a notebook does.
+
+This is the part of [Prime Agent's](https://github.com/PrimeIntellect-ai/prime-agent)
+design that made results worth naming — theirs is a live IPython kernel, this is
+a plain interpreter and newline-delimited JSON, which is enough to make a result
+a value you can compute over rather than a lookup you can only re-read.
+
+Tools are callable too, so a cell can drive a loop of them for one model
+round-trip instead of one per file:
+
+```python
+hits = grep(pattern='completionRate')
+files = sorted({l.split(':')[0] for l in hits.splitlines()[1:]})
+sizes = {f: len(read_file(path=f)) for f in files}
+```
+
+Each call blocks the cell until the host answers, so it reads exactly like the
+function it appears to be. A tool that fails raises `ToolError`, which the code
+around it can catch and act on.
+
+**Approving the scratchpad does not approve what the scratchpad can reach.** A
+tool that normally asks permission still asks when it is called from Python —
+otherwise an approved cell would be a way to edit files and run shell commands
+with no prompt at all, which is the gate the model would be routing around.
+
+### Does telling the model help?
+
+`bench/python-tool.js` measures it, because the answer was not obvious. The tool
+description carries three worked cells; the benchmark runs the same task with
+and without them, on a fixture where exports and file length vary independently
+so that the densest file is not the one with the most exports — no single tool
+call gets there.
+
+```
+model      nemotron-3-nano:4b        8 repeats per arm
+
+arm               correct   used python   calls   time
+without examples  0/8       0/8           7.1     9s
+with examples     3/8       8/8           3.8     6s
+```
+
+Tool selection is the decisive change: never reached for, to always reached for,
+at roughly half the tool calls. Accuracy moves from never right to sometimes
+right — the surviving failures are ordinary Python bugs, a different one each
+run, which is what a 4B model writing code looks like rather than a missing
+instruction.
+
+A fourth note, explaining that `glob` output begins with a summary line, was
+tried against the commonest error and made no measurable difference. It was
+removed rather than kept on the strength of the theory.
+
+```bash
+node bench/python-tool.js --repeats 8 qwen3:8b
+```
+
+It is **additive**, and that is deliberate. The ordinary tools remain and the
+model is free to ignore Python entirely, because writing correct code against
+live state is harder than emitting a tool call — and a bad line here can leave a
+namespace that later cells inherit. The tool asks permission like `run_command`,
+runs with the same sanitised environment so a cell cannot read your API keys,
+and is not offered at all when no interpreter is present.
+
+Detection runs the interpreter rather than trusting the name: on Windows
+`python3` is frequently an App Execution Alias that prints "Python was not
+found" and **exits 0**, so a `which`-style check reports success and the kernel
+then fails at the first cell with nothing to explain it.
+
+The namespace is **saved between runs**, so resuming a session brings back the
+variables, imports and helpers from the last one:
+
+```
+[restored from the last session: counts, json, pattern, rate, re]
+```
+
+Saved per variable rather than all at once, so one open file handle cannot take
+everything else with it — what could not be saved is named. Two things pickle
+cannot store are handled specially, because they are the commonest things a
+namespace holds: a **module** is recorded by name and imported again, and a
+**function or class** defined in a cell is saved as its source and replayed. A
+name later rebound to a value is restored as that value, not resurrected as the
+old function.
+
+The write is atomic, and a corrupt or missing snapshot is not an error — the
+kernel starts empty and says so, because losing variables is a nuisance while
+refusing to start is a broken session.
+
+A cell that does not finish within 30 seconds is killed. The kernel is
+single-threaded, so one hung cell would otherwise block every cell after it —
+and the loss of the namespace is reported rather than left to be discovered.
+
+## Credential containment
+
+The agent can run shell commands and write files, so anything reachable from its
+environment is one `echo` away from being exfiltrated. Two layers:
+
+1. **Secrets are stripped from child processes.** `run_command` spawns with a
+   sanitised environment — anything matching a credential-shaped name
+   (`*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, …) plus an explicit list of
+   known provider variables. `SSH_AUTH_SOCK`, `XAUTHORITY` and friends are
+   exempted, because removing them breaks `git push` for no security gain.
+2. **Live secret values are redacted from tool output.** Only values actually
+   present in the environment are masked, so redaction is precise. This catches
+   a credential arriving by another route — a `.env` file, a config dump, a
+   verbose log — before it reaches the transcript or a provider.
+
+Identifiers are deliberately *not* treated as credentials. Redaction matches on
+value, so classifying a session id as secret corrupted a real file path into
+`.../[redacted]/...` when that id was also a directory name.
+
+This is defence in depth, not a guarantee: an agent running arbitrary commands
+can still read a credentials file off disk. It removes the trivial paths.
+
+## Permissions
+
+`write_file`, `edit_file`, and `run_command` ask before running. Three answers,
+because two are not enough: **once**, **always for this tool**, or **no**.
+"Always" is scoped to the running process — a statement about this session, not
+a standing grant that silently persists into future runs. Add tool names to
+`autoApprove` for a durable grant.
+
+## Cross-platform by construction
+
+No shelling out to `sed`, `cat`, `find`, `which`, or `patch`. Filesystem work
+uses Node APIs and `fs.globSync`, so behaviour is identical on Windows and
+POSIX. The only shell is `run_command`, and the system prompt tells the model
+which shell it is actually talking to.
+
+## Performance and usage reporting
+
+This runs local models, and it feels like it. On a laptop with 8 GB of VRAM,
+`gemma4:12b` sits around 67% GPU / 33% CPU and a turn with a few tool calls
+takes minutes rather than seconds.
+
+Every turn ends with one number:
+
+```
+  ctx 1.3k/16k · 8%
+```
+
+Context is the only stat that is *news*. Throughput, time-to-first-token and
+elapsed time are constants of your hardware — you learn them once. Context
+climbs across a session and has a cliff: exceed `contextLength` and Ollama
+silently drops history, so the agent quietly forgets a file it read three turns
+ago, with no error anywhere. The line is dim below 70%, yellow at 70%, and red
+at 90% with an explanation.
+
+`/usage` expands to the full breakdown — input/output tokens, generation rate,
+prompt-eval rate, TTFT, model load, and the split between model time and time
+spent in tools. The numbers come from Ollama's own counters, not estimates, and
+two are computed deliberately:
+
+- **tok/s is measured against the model's eval duration**, not wall clock, so it
+  reports real throughput and is not dragged down by time in tools or a
+  cold-start load.
+- **ctx is a high-water mark, not a sum.** Each step resends the conversation,
+  so summing prompt tokens would imply the window was blown when it was not.
+
+## What live testing showed
+
+The rails above are not speculative — each was added after watching a specific
+failure, and several were built the wrong way first.
+
+**Escalation works, and raises the floor rather than the ceiling.** A weak
+primary handing off to a stronger model was demonstrated repeatedly; after
+handoff the stronger model traced a failure across files the weak one never
+approached. But no amount of rescue makes a task solvable that no available
+model can solve.
+
+**Malfunction is the minority failure.** Across five live runs, mechanical rails
+fired on two. The other three were confident and wrong, with every tool call
+succeeding — which is why verification exists.
+
+**Verification changes outcomes.** Replaying the exact turn that failed before:
+the model read one line, claimed absence, was told its evidence was thin,
+re-read the whole file and answered correctly — *without* escalating. The weak
+model could do the task all along; it needed to be told its evidence was thin.
+
+**Detection is not capability.** A cross-file bug — the failing test names one
+module, the cause lives in another — was attempted four times by `qwen3:8b`,
+with and without every rail. It never solved it, and a control run with all
+rails off failed identically. The checks made the failure *loud* instead of
+silent, which is the real win: without them the run ended with a nonsense edit
+in place and a confident summary.
+
+**Context growth is the cost driver.** A trivial four-step turn consumed 6.5k
+input tokens, because each step resends the whole conversation plus ~4 KB of
+tool schemas. Free on Ollama, expensive on a metered API.
+
+## Tests
+
+```bash
+npm test
+```
+
+126 tests covering tool-name repair, argument validation and coercion, dispatch
+error containment, availability probes, output truncation and overflow recovery,
+workspace path containment, call-identity hashing, permission gating,
+credential containment, usage accounting, escalation triggers and handoff state,
+model recommendation across hardware profiles, and every verification check —
+including regression tests for each false positive found in live runs.

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,157 @@
+# Choosing models
+
+How cloi decides which models to run on your machine, and the measurements behind those
+choices. Summarised in the README; this is the working.
+
+## Choosing models
+
+The hardest decision for a new user is which model to run, and getting it wrong
+produces an agent that looks *broken* rather than one that looks slow. So it is
+measured rather than guessed.
+
+`cloi setup` reads VRAM, system RAM and core count, then proposes two models
+against **different constraints** — which is the whole idea:
+
+- The **primary** runs every step of every turn, so it must fit in VRAM. A model
+  that spills is not slightly slower, it is several times slower, and that cost
+  is paid on each of the dozen-odd model calls a turn makes.
+- The **escalation** model runs rarely, only when a turn is already going wrong,
+  so it is allowed to spill. It only has to fit in RAM. A few slow minutes on a
+  turn that would otherwise fail outright is a good trade.
+
+```
+NVIDIA GeForce RTX 5060 Laptop GPU · 8.0 GB VRAM · 31.4 GB RAM · 20 cores
+
+primary   qwen3:8b       5.2 GB · best small model for agent loops
+fallback  qwen3:30b-a3b   18 GB · mixture-of-experts: 3B active, so it stays
+                                  fast even when it spills to RAM
+```
+
+Sample recommendations:
+
+| Machine | Primary | Escalation |
+|---|---|---|
+| No GPU, 16 GB RAM | `qwen3:4b` | `qwen3:14b` |
+| 6 GB VRAM, 16 GB RAM | `qwen3:4b` | `qwen3:14b` |
+| 8 GB VRAM, 32 GB RAM | `qwen3:8b` | `qwen3:30b-a3b` |
+| 16 GB VRAM, 32 GB RAM | `qwen3:14b` | `qwen3:30b-a3b` |
+| 24 GB VRAM, 64 GB RAM | `qwen3:32b` | — |
+
+Five details that matter, all of them corrected by measurement rather than
+reasoned from first principles:
+
+- **The bar is ~60% VRAM residency, not a full fit.** On an 8 GB card only a 4B
+  model fits entirely, and dropping two tiers of capability to avoid a 20% spill
+  is the wrong trade.
+- **Fit uses an additive reserve, not a multiplier.** The overhead beyond the
+  weights is the KV cache, which scales with the *context window* rather than
+  model size. A multiplier refused a 20 GB model on a 24 GB card that holds it
+  fine.
+- **A primary is stepped down when it would leave nothing to escalate to.** A
+  faster primary plus a working fallback beats a bloated primary alone.
+- **A mixture-of-experts model is preferred for escalation when it will spill.**
+  Only its active parameters cost time, so `qwen3:30b-a3b` stays usable on CPU
+  where a dense model of the same footprint would not.
+- **Thresholds sit under the nominal card size.** An "8 GB" card reports 8151
+  MiB — 7.96 GiB — so a naive `>= 8` would quietly drop it a tier.
+
+### Which models, and why those
+
+The catalog spans families rather than betting on one vendor, and entries were
+chosen from a local run through this registry — not from public leaderboards,
+which use their own tools and prompts.
+
+`bench/compare.js` runs candidate models against the real eight tools with
+escalation and judging disabled, on tasks with checkable answers:
+
+Eight tasks across three difficulty bands, three repeats each, scored
+mechanically — a regex over the answer, or the exit code of the project's own
+test suite:
+
+```
+model                  pass rate      easy   medium   hard   tok/s (sd)
+qwen3:8b               11/24 (46%)    8/9    3/9      0/6    33.7 (5.2)
+nemotron-3-nano:4b     15/24 (63%)    8/9    7/9      0/6    98.8 (18.7)
+```
+
+Three results shaped the catalog:
+
+- **Nemotron wins on a smaller model.** 63% against 46%, and 7/9 against 3/9 on
+  medium tasks, at 2.8 GB and roughly three times the throughput. So catalog
+  *tier means measured capability, not size* — ordering by size would hand an
+  8 GB card the weaker model purely because it is bigger.
+- **Hard tasks are 0/12 for both.** Not one pass in twelve attempts at tracing a
+  bug across files. That is the ceiling, stated with real n rather than inferred.
+- **Neither over-triggers.** Both scored 3/3 on a task that passes only if *no*
+  tool is called, which the relevance/irrelevance splits in public benchmarks
+  suggested was a genuine risk.
+
+A `~` marks any task passed only sometimes — unreliability is a different
+failure from incapability, and matters more inside a loop.
+
+An earlier three-task version of this benchmark ranked the two models as tied.
+It was too easy to discriminate, and its scorer was wrong: an answer of "it is in
+stats.js, **not** report.js" was marked incorrect for naming the distractor —
+penalising precision. Scoring now takes the first non-negated file mentioned,
+verified against twelve hand-written cases covering both word orders.
+
+**Gemma 4** is deliberately absent despite being tool-capable and Apache-2.0. It
+came last here — hitting the iteration ceiling on a task the others finished in
+four steps — which matches independent results giving Qwen 3.6 large agentic
+margins (SWE-bench +21.4, MCPMark +18.9, TAU2 +13). Gemma 4 wins math and
+multimodal; this loop uses neither.
+
+**Nemotron 3 Super and Ultra** are 120B and 550B, and Ultra is cloud-only on
+Ollama, so neither fits a laptop.
+
+Run it yourself against anything you like:
+
+```bash
+node bench/compare.js qwen3:8b nemotron-3-nano:4b your-model:tag
+```
+
+### The prediction is checked against reality
+
+Probes read the card; they can still be wrong on hardware nobody has tested. So
+after the primary is pulled, setup loads it and asks Ollama where it actually
+went:
+
+```
+82% of qwen3:8b is resident in VRAM
+```
+
+That number comes from `size_vram / size` on `/api/ps`, which reflects **Ollama's
+own GPU detection** — covering NVIDIA, AMD, Intel and Metal, including hardware
+these probes cannot read. If residency comes back below 40%, the primary is
+stepped down automatically and you are told why.
+
+The constants are calibrated against that measurement: on this machine the
+prediction was 82% and the observed value 80%, a two-point error. There is no
+Ollama endpoint reporting card capacity — `/api/gpu`, `/api/hardware`,
+`/api/system` all 404 — so the placement of a real model is the closest thing to
+ground truth available.
+
+VRAM is probed in order of how reliable the number is: `nvidia-smi`, then
+`rocm-smi` for AMD, then the Windows display-adapter registry (covering AMD and
+Intel), then Linux sysfs. Apple Silicon is treated as unified memory at roughly
+two thirds of system RAM.
+
+Two Windows traps are worth naming, since both silently produce a wrong answer
+rather than an error. WMI's `AdapterRAM` is a 32-bit field that reports *any*
+card above 4 GB as exactly 4 GB — so the registry's 64-bit `qwMemorySize` is
+used instead. And that value is a *flat* property whose name contains a dot, so
+it must be quoted: dot-traversal reads `null` and makes every machine look like
+it has no GPU.
+
+Every probe returns null rather than a guess. If nothing is detectable the
+recommendation drops to a CPU-sized model, because suggesting something too
+large fails confusingly while suggesting something too small merely
+underperforms.
+
+Downloads go through Ollama's HTTP API rather than the `ollama` binary, which
+may not be on `PATH` even when the server is reachable. A failed download never
+discards the recommendation — the config is written either way, so you are never
+left with no model configured.
+
+`npm install` prints a one-line pointer to `cloi setup` and does nothing else:
+no hardware probing, no network, no writes. It is silent under `CI`.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "bin/",
     "src/",
+    "docs/",
     "README.md",
     "LICENSE"
   ],

--- a/src/agent/loop.js
+++ b/src/agent/loop.js
@@ -107,6 +107,11 @@ export async function runTurn({
     session,
     ui,
     signal,
+    // The python tool exposes the other tools as callables, so it needs the
+    // registry to find them and the permission manager to gate them. Approving
+    // a scratchpad must not silently approve everything it can reach.
+    registry,
+    permissions,
   };
 
   /** Counts of identical calls this turn, keyed by name+args. */

--- a/src/agent/prompt.js
+++ b/src/agent/prompt.js
@@ -21,16 +21,7 @@ export function buildSystemPrompt({ cwd, toolNames, todos = [] }) {
     `- Shell for run_command: ${shellName()}`,
     '',
     'Rules:',
-    '1. Use tools to find things out. Never guess a file\'s contents, and never invent file paths — locate them with glob or grep first.',
-    '2. Before editing a file, read it. edit_file requires the exact existing text, including indentation.',
-    '3. Take one step at a time. Call a tool, read the result, then decide the next step.',
-    '4. Paths are relative to the workspace root. You cannot access files outside it.',
-    '5. A result ending in "[saved as <name>]" was stored in full. To look at more of it, '
-      + 'call recall with that name — with a pattern to search inside it, or start_line/end_line '
-      + 'for a slice. What you were shown may have been truncated, and the stored copy is complete. '
-      + 'Never re-read a file or repeat a search to see something you already fetched.',
-    '6. When you have finished, reply with plain text and no tool calls. That ends your turn.',
-    '7. Keep replies short. Report what you did and what you found, not what you are about to do.',
+    ...numbered(rules(toolNames)),
   ];
 
   if (toolNames?.length) {
@@ -49,4 +40,47 @@ export function buildSystemPrompt({ cwd, toolNames, todos = [] }) {
   }
 
   return lines.join('\n');
+}
+
+/**
+ * The rules, as a plain list.
+ *
+ * Numbered when rendered rather than in the text, because a rule that only
+ * applies when a tool is present would otherwise leave a gap in the sequence —
+ * and a model reading "1, 2, 4" wonders what it was not told.
+ */
+function rules(toolNames = []) {
+  const list = [
+    'Use tools to find things out. Never guess the contents of a file, and never invent file paths — locate them with glob or grep first.',
+    'Before editing a file, read it. edit_file requires the exact existing text, including indentation.',
+    'Take one step at a time. Call a tool, read the result, then decide the next step.',
+    'Paths are relative to the workspace root. You cannot access files outside it.',
+    'A result ending in "[saved as <name>]" was stored in full. To look at more of it, '
+      + 'call recall with that name - with a pattern to search inside it, or start_line/end_line '
+      + 'for a slice. What you were shown may have been truncated, and the stored copy is complete. '
+      + 'Never re-read a file or repeat a search to see something you already fetched.',
+  ];
+
+  // Only when the interpreter exists. Describing a tool the model has not been
+  // given is worse than silence: it spends a turn calling something that is not
+  // there, and the repair costs another.
+  if (toolNames.includes('python')) {
+    list.push(
+      'Repetitive work over many files or many matches belongs in one python cell, not one tool '
+      + 'call per item. Stored results are already variables there, and every tool is callable as '
+      + 'a function - so read_file(path=p) inside a loop does in one step what would otherwise '
+      + 'take ten. That is still one step: the cell is the step.',
+    );
+  }
+
+  list.push(
+    'When you have finished, reply with plain text and no tool calls. That ends your turn.',
+    'Keep replies short. Report what you did and what you found, not what you are about to do.',
+  );
+  return list;
+}
+
+/** Render a list as "1. …", so the numbering can never drift from the content. */
+function numbered(list) {
+  return list.map((rule, i) => `${i + 1}. ${rule}`);
 }

--- a/src/agent/verify.js
+++ b/src/agent/verify.js
@@ -21,7 +21,13 @@ import fs from 'node:fs';
 import { resolvePath, displayPath, isProbablyBinary, looksBinary, walkFiles } from '../tools/workspace.js';
 
 /** Extensions worth treating as a file reference in prose. */
-const CODE_EXT = /\.(?:js|mjs|cjs|jsx|ts|tsx|py|rb|go|rs|java|kt|c|h|cpp|hpp|cs|php|swift|sh|json|ya?ml|toml|md|sql)$/i;
+// Data and document files count too. Without them a claim to have written
+// "endpoint_list.txt" was never checked at all, and the agent asserted three
+// times that it had created a file it never created.
+//
+// `log` and `env` are deliberately absent: `console.log` and `process.env`
+// parse as filenames and appear constantly in ordinary prose about code.
+const CODE_EXT = /\.(?:js|mjs|cjs|jsx|ts|tsx|py|rb|go|rs|java|kt|c|h|cpp|hpp|cs|php|swift|sh|json|ya?ml|toml|md|sql|txt|csv|tsv|html?|xml)$/i;
 
 /**
  * Names that end in a source extension but are technologies, not files.

--- a/src/config.js
+++ b/src/config.js
@@ -105,14 +105,62 @@ const DEFAULTS = {
   showUsage: true,
 };
 
+/** Bumped when a default changes in a way a saved config would otherwise pin. */
+const CONFIG_VERSION = 2;
+
+/**
+ * Settings whose default changed, with the value they used to default to.
+ *
+ * A saved config records what setup wrote, not what the user chose, so a value
+ * still equal to the old default was never a decision — and leaving it pinned
+ * means an existing install never receives the fix. `think: false` in
+ * particular did not merely keep the old behaviour: it is the setting under
+ * which a reasoning model's monologue is streamed into the answer.
+ *
+ * This cannot tell a deliberate `false` from an inherited one. That is the
+ * trade, taken because these were defaults nobody was ever asked about.
+ */
+const SUPERSEDED = {
+  think: false,
+  judgeAnswers: true,
+};
+
 let cached = null;
+
+/** Drop values a config only holds because they used to be the default. */
+function migrate(fromFile) {
+  if (fromFile.configVersion >= CONFIG_VERSION) return fromFile;
+
+  const migrated = { ...fromFile };
+  const dropped = [];
+  for (const [key, oldDefault] of Object.entries(SUPERSEDED)) {
+    if (key in migrated && migrated[key] === oldDefault) {
+      delete migrated[key];
+      dropped.push(key);
+    }
+  }
+  migrated.configVersion = CONFIG_VERSION;
+
+  try {
+    // Written directly rather than through saveConfig, which loads config and
+    // would re-enter this.
+    ensureDataDir();
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(migrated, null, 2), 'utf8');
+  } catch {
+    // An unwritable config still migrates for this run; it just does not stick.
+  }
+  if (dropped.length) {
+    console.error(`cloi: ${dropped.join(', ')} now follow the current defaults.`);
+  }
+  return migrated;
+}
 
 export function loadConfig() {
   if (cached) return cached;
   let fromFile = {};
   try {
     if (fs.existsSync(CONFIG_PATH)) {
-      fromFile = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+      fromFile = migrate(JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8')));
     }
   } catch (err) {
     // A corrupt config should degrade to defaults, not prevent startup.

--- a/src/session/naming.js
+++ b/src/session/naming.js
@@ -1,0 +1,118 @@
+/**
+ * Names for stored tool results.
+ *
+ * `read_1` says only which tool ran and in what order — the model has to fetch
+ * a result to remember what is in it. A name taken from the arguments carries
+ * the answer: `stats_js` holds `src/lib/stats.js`, `npm_test` holds the output
+ * of `npm test`.
+ *
+ * These are bound as variables in the Python kernel, so a name is not merely a
+ * label: it has to be a valid identifier, it must not collide with a tool
+ * function or a builtin, and `stats_js.splitlines()` has to read as code.
+ */
+
+/** Fallbacks when the arguments carry nothing worth naming. */
+const TOOL_LABELS = {
+  read_file: 'read',
+  write_file: 'write',
+  edit_file: 'edit',
+  run_command: 'run',
+  list_dir: 'ls',
+};
+
+/**
+ * Names a result must never take.
+ *
+ * A handle that shadows `grep` would replace the tool function with a string,
+ * and the next cell calling `grep(pattern=...)` fails with something that looks
+ * nothing like the cause. Python keywords and the builtins most likely to be
+ * used in a cell are reserved for the same reason.
+ */
+const RESERVED = new Set([
+  'read_file', 'write_file', 'edit_file', 'list_dir', 'glob', 'grep',
+  'run_command', 'update_plan', 'recall', 'python', 'ToolError',
+  'and', 'as', 'assert', 'break', 'class', 'continue', 'def', 'del', 'elif',
+  'else', 'except', 'finally', 'for', 'from', 'global', 'if', 'import', 'in',
+  'is', 'lambda', 'none', 'not', 'or', 'pass', 'raise', 'return', 'true',
+  'false', 'try', 'while', 'with', 'yield', 'async', 'await', 'nonlocal',
+  'len', 'list', 'dict', 'set', 'str', 'int', 'float', 'open', 'print',
+  'sum', 'min', 'max', 'sorted', 'type', 'range', 'map', 'filter', 'input',
+]);
+
+/** Long enough to be recognisable, short enough to type in a cell. */
+const MAX_LENGTH = 28;
+
+/** Lowercase, identifier-safe, no runs of underscores. */
+function slug(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, MAX_LENGTH)
+    .replace(/_+$/, '');
+}
+
+/**
+ * The part of the arguments worth naming the result after.
+ *
+ * A path is reduced to its filename: the directory is what the paths have in
+ * common, so it is the part that distinguishes nothing.
+ */
+function subject(toolName, args = {}) {
+  switch (toolName) {
+    case 'read_file':
+    case 'write_file':
+    case 'edit_file':
+      return basename(args.path);
+    case 'list_dir':
+      return `ls_${basename(args.path) || 'root'}`;
+    case 'glob':
+      // `**/*.py` has nothing but the extension to go on.
+      return `glob_${slug(String(args.pattern || '').replace(/[*/.]/g, ' ')) || 'files'}`;
+    case 'grep':
+      return `grep_${slug(args.pattern) || 'search'}`;
+    case 'run_command': {
+      // The last segment of a chain, not the first: `cd demo && python x.py`
+      // is about `x.py`, and naming it `cd_demo` describes the setup rather
+      // than the work.
+      const last = String(args.command || '').split(/&&|\|\||;/).pop() || '';
+      const words = last.trim().split(/\s+/).filter((w) => w && !w.startsWith('-'));
+      return slug(words.slice(0, 2).join(' ')) || 'run';
+    }
+    default:
+      return '';
+  }
+}
+
+function basename(filePath) {
+  if (!filePath) return '';
+  const last = String(filePath).split(/[/\\]/).filter(Boolean).pop() || '';
+  return slug(last);
+}
+
+/**
+ * Choose a name for a result.
+ *
+ * @param {string} toolName
+ * @param {object} args Arguments the tool was called with.
+ * @param {(name: string) => boolean} taken Whether a name is already in use.
+ * @returns {string}
+ */
+export function resultName(toolName, args, taken = () => false) {
+  let base = subject(toolName, args) || TOOL_LABELS[toolName] || slug(toolName) || 'result';
+
+  // An identifier cannot start with a digit, and a reserved word cannot be
+  // rebound. Both are fixed by prefixing with what the tool was.
+  if (/^[0-9]/.test(base) || RESERVED.has(base)) {
+    base = `${TOOL_LABELS[toolName] || slug(toolName)}_${base}`;
+  }
+
+  if (!taken(base)) return base;
+  // Same file read twice is a second result, not a replacement: the first may
+  // predate an edit, and a name that silently rebinds would hide that.
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${base}_${n}`;
+    if (!taken(candidate)) return candidate;
+  }
+  return `${base}_${Date.now()}`;
+}

--- a/src/session/store.js
+++ b/src/session/store.js
@@ -13,6 +13,7 @@
 import { DatabaseSync } from 'node:sqlite';
 import { randomUUID } from 'node:crypto';
 import { DB_PATH, ensureDataDir } from '../util/paths.js';
+import { resultName } from './naming.js';
 
 let db = null;
 
@@ -87,15 +88,6 @@ export function getDb() {
   `);
   return db;
 }
-
-/** Short, readable handle prefixes. `read_file` reads better as `read_3`. */
-const RESULT_LABELS = {
-  read_file: 'read',
-  run_command: 'run',
-  list_dir: 'ls',
-  write_file: 'write',
-  edit_file: 'edit',
-};
 
 export class Session {
   constructor(row) {
@@ -211,11 +203,7 @@ export class Session {
    * @returns {string} The name the model can recall it by.
    */
   saveResult({ toolName, args, content }) {
-    const label = RESULT_LABELS[toolName] || toolName.replace(/_.*$/, '');
-    const row = getDb()
-      .prepare('SELECT COUNT(*) AS n FROM results WHERE session_id = ? AND tool_name = ?')
-      .get(this.id, toolName);
-    const name = `${label}_${(row?.n ?? 0) + 1}`;
+    const name = resultName(toolName, args, (candidate) => !!this.getResult(candidate));
 
     getDb()
       .prepare(`

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -11,6 +11,7 @@ import { registerFsTools } from './fs-tools.js';
 import { registerShellTool } from './shell.js';
 import { registerTodoTool } from './todo.js';
 import { registerRecallTool } from './recall.js';
+import { registerPythonTool } from './python.js';
 
 export function createRegistry() {
   const registry = new ToolRegistry();
@@ -18,6 +19,7 @@ export function createRegistry() {
   registerShellTool(registry);
   registerTodoTool(registry);
   registerRecallTool(registry);
+  registerPythonTool(registry);
   return registry;
 }
 

--- a/src/tools/kernel.js
+++ b/src/tools/kernel.js
@@ -1,0 +1,191 @@
+/**
+ * A Python process that outlives a single tool call.
+ *
+ * This is the piece that makes a result a *variable* rather than a lookup:
+ * `matches` bound in one call is still bound in the next, and can be filtered,
+ * counted, or passed to something else. Prime Agent gets that from a live
+ * IPython kernel; this is the same idea with the smallest machinery that
+ * delivers it — a long-lived interpreter and newline-delimited JSON.
+ *
+ * One kernel per session. It is started on first use, not at launch: most turns
+ * never need Python, and paying a process spawn for all of them would be a
+ * tax on the common case.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { sanitizeEnv } from '../util/secrets.js';
+
+const DRIVER = fileURLToPath(new URL('./kernel.py', import.meta.url));
+
+/** Interpreters to try, best first. */
+const CANDIDATES = ['python3', 'python', 'py'];
+
+/** A cell that has not answered by now is not going to. */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+let detected;
+
+/**
+ * Find a Python that actually runs.
+ *
+ * Not a `which` check. On Windows `python3` is frequently an App Execution
+ * Alias that prints "Python was not found; run without arguments to install
+ * from the Microsoft Store" and **exits 0** — so a naive probe reports success
+ * and the kernel then fails at the first cell with nothing to explain it. The
+ * only reliable test is asking it to print its own version.
+ *
+ * @returns {string|null}
+ */
+export function detectPython({ force = false } = {}) {
+  if (detected !== undefined && !force) return detected;
+
+  for (const command of CANDIDATES) {
+    try {
+      const probe = spawnSync(command, ['-c', 'import sys; print(sys.version_info[0])'], {
+        encoding: 'utf8',
+        timeout: 5000,
+        windowsHide: true,
+      });
+      if (probe.status === 0 && probe.stdout.trim() === '3') {
+        detected = command;
+        return detected;
+      }
+    } catch {
+      // Not on PATH; try the next one.
+    }
+  }
+  detected = null;
+  return detected;
+}
+
+export class PythonKernel {
+  constructor({ cwd, command, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+    this.cwd = cwd;
+    this.command = command || detectPython();
+    this.timeoutMs = timeoutMs;
+    this.child = null;
+    this.buffer = '';
+    /** Requests are answered in order, so one queue is enough. */
+    this.pending = [];
+    /** Handles already bound, so a rebind costs nothing. */
+    this.bound = new Set();
+  }
+
+  get running() {
+    return !!this.child && !this.child.killed && this.child.exitCode === null;
+  }
+
+  start() {
+    if (this.running) return;
+    if (!this.command) throw new Error('No Python 3 interpreter found on PATH.');
+
+    this.child = spawn(this.command, ['-u', DRIVER], {
+      cwd: this.cwd,
+      // Same containment as run_command: a subprocess started by the agent has
+      // no business seeing the API keys of the shell that launched cloi.
+      env: sanitizeEnv(process.env),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    this.child.stdout.setEncoding('utf8');
+    this.child.stdout.on('data', (chunk) => this._consume(chunk));
+
+    this.stderr = '';
+    this.child.stderr.setEncoding('utf8');
+    this.child.stderr.on('data', (chunk) => { this.stderr = (this.stderr + chunk).slice(-4000); });
+
+    const fail = (reason) => {
+      const waiting = this.pending.splice(0);
+      for (const { reject } of waiting) reject(new Error(reason));
+      this.child = null;
+      this.bound.clear();
+    };
+    this.child.on('exit', (code) => fail(`Python kernel exited (code ${code}). ${this.stderr}`.trim()));
+    this.child.on('error', (err) => fail(`Python kernel failed to start: ${err.message}`));
+  }
+
+  _consume(chunk) {
+    this.buffer += chunk;
+    let newline;
+    while ((newline = this.buffer.indexOf('\n')) !== -1) {
+      const line = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (!line) continue;
+
+      const waiter = this.pending.shift();
+      if (!waiter) continue;
+      clearTimeout(waiter.timer);
+      try {
+        waiter.resolve(JSON.parse(line));
+      } catch {
+        waiter.reject(new Error(`Unreadable kernel reply: ${line.slice(0, 200)}`));
+      }
+    }
+  }
+
+  _send(message) {
+    this.start();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        // The kernel is single-threaded, so a cell that hangs blocks every cell
+        // after it. Killing is the only way back, and the namespace goes with
+        // it — which is worth saying rather than silently starting over.
+        const index = this.pending.findIndex((p) => p.timer === timer);
+        if (index !== -1) this.pending.splice(index, 1);
+        this.kill();
+        reject(new Error(`Python did not finish within ${Math.round(this.timeoutMs / 1000)}s; the kernel was restarted and its variables are gone.`));
+      }, this.timeoutMs);
+
+      this.pending.push({ resolve, reject, timer });
+      this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    });
+  }
+
+  /** Define variables in the namespace. Values are strings. */
+  bind(vars) {
+    const fresh = {};
+    for (const [name, value] of Object.entries(vars)) {
+      if (!this.bound.has(name)) fresh[name] = value;
+    }
+    if (!Object.keys(fresh).length) return Promise.resolve({ ok: true, bound: [] });
+    for (const name of Object.keys(fresh)) this.bound.add(name);
+    return this._send({ type: 'bind', vars: fresh });
+  }
+
+  exec(code) {
+    return this._send({ type: 'exec', code });
+  }
+
+  names() {
+    return this._send({ type: 'names' });
+  }
+
+  kill() {
+    if (this.child) {
+      this.child.kill('SIGKILL');
+      this.child = null;
+    }
+    this.bound.clear();
+    this.buffer = '';
+  }
+}
+
+/** One kernel per session, created on first use. */
+const kernels = new Map();
+
+export function kernelFor(sessionId, options) {
+  let kernel = kernels.get(sessionId);
+  if (!kernel || !kernel.command) {
+    kernel = new PythonKernel(options);
+    kernels.set(sessionId, kernel);
+  }
+  return kernel;
+}
+
+export function shutdownKernels() {
+  for (const kernel of kernels.values()) kernel.kill();
+  kernels.clear();
+}

--- a/src/tools/kernel.js
+++ b/src/tools/kernel.js
@@ -24,6 +24,10 @@ const CANDIDATES = ['python3', 'python', 'py'];
 
 /** A cell that has not answered by now is not going to. */
 export const DEFAULT_TIMEOUT_MS = 30_000;
+/** Quiet period after a cell before the namespace is written to disk. */
+const SNAPSHOT_DEBOUNCE_MS = 1_500;
+/** Ceiling on a saved namespace, checked per variable and in total. */
+const SNAPSHOT_MAX_BYTES = 32 * 1024 * 1024;
 
 let detected;
 
@@ -61,10 +65,14 @@ export function detectPython({ force = false } = {}) {
 }
 
 export class PythonKernel {
-  constructor({ cwd, command, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  constructor({ cwd, command, timeoutMs = DEFAULT_TIMEOUT_MS, snapshotPath = null } = {}) {
     this.cwd = cwd;
     this.command = command || detectPython();
     this.timeoutMs = timeoutMs;
+    this.snapshotPath = snapshotPath;
+    /** Result of the restore done at startup, for the first cell to report. */
+    this.restored = null;
+    this.snapshotTimer = null;
     this.child = null;
     this.buffer = '';
     /** Requests are answered in order, so one queue is enough. */
@@ -105,6 +113,16 @@ export class PythonKernel {
     };
     this.child.on('exit', (code) => fail(`Python kernel exited (code ${code}). ${this.stderr}`.trim()));
     this.child.on('error', (err) => fail(`Python kernel failed to start: ${err.message}`));
+
+    // Restored first, before tools are installed and handles rebound, so a
+    // fresh tool function always wins over a stale copy of one. Queued rather
+    // than awaited: the caller's own message is written straight after and the
+    // driver answers in order.
+    if (this.snapshotPath) {
+      this._enqueue({ type: 'restore', path: this.snapshotPath })
+        .then((result) => { this.restored = result; })
+        .catch(() => { this.restored = null; });
+    }
   }
 
   _consume(chunk) {
@@ -186,8 +204,60 @@ export class PythonKernel {
     return this._send({ type: 'tools', names });
   }
 
+  /**
+   * Write the namespace to disk.
+   *
+   * Debounced: a cell that assigns one variable does not need its own write,
+   * and the interesting moment is when the agent stops working, not each step.
+   */
+  scheduleSnapshot() {
+    if (!this.snapshotPath || !this.running) return;
+    clearTimeout(this.snapshotTimer);
+    this.snapshotTimer = setTimeout(() => { void this.snapshot(); }, SNAPSHOT_DEBOUNCE_MS);
+    this.snapshotTimer.unref?.();
+  }
+
+  /**
+   * What a restore recovered, reported once.
+   *
+   * The agent needs to know its variables came back — otherwise it redefines
+   * them — and needs to know when one did not, since a name that silently
+   * failed to unpickle would raise NameError several cells later with nothing
+   * to connect it to.
+   */
+  takeRestoreNotice() {
+    const restored = this.restored;
+    this.restored = null;
+    if (!restored?.restored?.length && !restored?.failed?.length) return null;
+
+    const parts = [];
+    if (restored.restored.length) {
+      parts.push(`[restored from the last session: ${restored.restored.join(', ')}]`);
+    }
+    if (restored.failed?.length) {
+      parts.push(`[could not restore: ${restored.failed.map((f) => f.name).join(', ')}]`);
+    }
+    return parts.join('\n');
+  }
+
+  async snapshot() {
+    if (!this.snapshotPath || !this.running) return null;
+    clearTimeout(this.snapshotTimer);
+    try {
+      return await this._send({ type: 'snapshot', path: this.snapshotPath, maxBytes: SNAPSHOT_MAX_BYTES });
+    } catch {
+      // Losing a snapshot costs the next session its variables. Losing the turn
+      // to say so would cost more.
+      return null;
+    }
+  }
+
   _send(message) {
     this.start();
+    return this._enqueue(message);
+  }
+
+  _enqueue(message) {
     return new Promise((resolve, reject) => {
       // The kernel is single-threaded, so a cell that hangs blocks every cell
       // after it. Killing is the only way back, and the namespace goes with it
@@ -219,6 +289,8 @@ export class PythonKernel {
   }
 
   kill() {
+    clearTimeout(this.snapshotTimer);
+    this.snapshotTimer = null;
     if (this.child) {
       this.child.kill('SIGKILL');
       this.child = null;

--- a/src/tools/kernel.js
+++ b/src/tools/kernel.js
@@ -115,31 +115,86 @@ export class PythonKernel {
       this.buffer = this.buffer.slice(newline + 1);
       if (!line) continue;
 
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        const broken = this.pending.shift();
+        if (broken) {
+          clearTimeout(broken.timer);
+          broken.reject(new Error(`Unreadable kernel reply: ${line.slice(0, 200)}`));
+        }
+        continue;
+      }
+
+      // A call arrives *during* an execution, not instead of it: the cell is
+      // still running and blocked on the answer, so the pending waiter stays
+      // where it is.
+      if (message.type === 'call') {
+        this._serveCall(message);
+        continue;
+      }
+
       const waiter = this.pending.shift();
       if (!waiter) continue;
       clearTimeout(waiter.timer);
-      try {
-        waiter.resolve(JSON.parse(line));
-      } catch {
-        waiter.reject(new Error(`Unreadable kernel reply: ${line.slice(0, 200)}`));
-      }
+      waiter.resolve(message);
     }
+  }
+
+  /**
+   * Run a tool on the cell's behalf and hand the result back.
+   *
+   * The waiting cell's timeout is suspended for the duration: a tool call is
+   * work the cell asked for, and a `run_command` that takes a minute should not
+   * look like a hung interpreter.
+   */
+  async _serveCall(message) {
+    const waiter = this.pending[0];
+    if (waiter) clearTimeout(waiter.timer);
+
+    let payload;
+    try {
+      if (!this.onCall) throw new Error('this kernel cannot call tools');
+      payload = { ok: true, output: await this.onCall(message) };
+    } catch (err) {
+      payload = { ok: false, error: err?.message || String(err) };
+    }
+
+    // The cell may already be gone — a timeout, or the kernel killed under it.
+    if (!this.running) return;
+    if (waiter && this.pending[0] === waiter) waiter.timer = this._armTimeout(waiter);
+    this.child.stdin.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  _armTimeout(waiter) {
+    const timer = setTimeout(() => {
+      const index = this.pending.indexOf(waiter);
+      if (index !== -1) this.pending.splice(index, 1);
+      this.kill();
+      waiter.reject(new Error(
+        `Python did not finish within ${Math.round(this.timeoutMs / 1000)}s; `
+        + 'the kernel was restarted and its variables are gone.',
+      ));
+    }, this.timeoutMs);
+    timer.unref?.();
+    return timer;
+  }
+
+  /** Expose these tool names as functions inside the kernel. */
+  installTools(names) {
+    return this._send({ type: 'tools', names });
   }
 
   _send(message) {
     this.start();
     return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        // The kernel is single-threaded, so a cell that hangs blocks every cell
-        // after it. Killing is the only way back, and the namespace goes with
-        // it — which is worth saying rather than silently starting over.
-        const index = this.pending.findIndex((p) => p.timer === timer);
-        if (index !== -1) this.pending.splice(index, 1);
-        this.kill();
-        reject(new Error(`Python did not finish within ${Math.round(this.timeoutMs / 1000)}s; the kernel was restarted and its variables are gone.`));
-      }, this.timeoutMs);
-
-      this.pending.push({ resolve, reject, timer });
+      // The kernel is single-threaded, so a cell that hangs blocks every cell
+      // after it. Killing is the only way back, and the namespace goes with it
+      // — which is worth saying rather than silently starting over.
+      const waiter = { resolve, reject };
+      waiter.timer = this._armTimeout(waiter);
+      this.pending.push(waiter);
       this.child.stdin.write(`${JSON.stringify(message)}\n`);
     });
   }

--- a/src/tools/kernel.py
+++ b/src/tools/kernel.py
@@ -24,6 +24,13 @@ NS = {"__name__": "__cloi__", "__builtins__": __builtins__}
 # are there because it was told.
 INSTALLED = set()
 
+# Source of every function and class the agent defined, by name.
+#
+# pickle serialises a function by reference, not by value, so a helper defined
+# in a cell cannot be saved — and a helper the agent wrote is exactly the kind
+# of thing worth keeping. Its source is replayed on restore instead.
+DEFS = {}
+
 # Protocol writes must not be captured along with the code's own output, so the
 # real streams are captured once, before anything is ever redirected.
 PROTOCOL_OUT = sys.stdout
@@ -94,6 +101,11 @@ def run(code):
             # returned nothing — which is not how a notebook behaves, and not
             # what the tool description promises.
             tree = ast.parse(code, "<cell>", "exec")
+            for node in tree.body:
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    segment = ast.get_source_segment(code, node)
+                    if segment:
+                        DEFS[node.name] = segment
             if tree.body and isinstance(tree.body[-1], ast.Expr):
                 head = ast.Module(body=tree.body[:-1], type_ignores=[])
                 tail = ast.Expression(body=tree.body[-1].value)
@@ -122,6 +134,120 @@ def names():
     return sorted(k for k in NS if not k.startswith("_") and k not in INSTALLED)
 
 
+# Tool functions are reinstalled on every start and stored handles are rebound
+# from the database, so snapshotting either would only restore a stale copy over
+# a fresh one.
+def snapshot(path, max_bytes):
+    import builtins as _b
+    import os
+    import pickle
+    import types
+
+    payload = {}
+    # Modules cannot be pickled, but they do not need to be: the name is enough
+    # to import them again. Without this an `import re` in one session is gone
+    # in the next, which is the commonest thing a namespace holds.
+    modules = {}
+    skipped = []
+    total = 0
+
+    for name in names():
+        value = NS[name]
+        if isinstance(value, types.ModuleType):
+            modules[name] = value.__name__
+            continue
+        # A definition is saved as source below. Attempting to pickle it first
+        # would report it as skipped and saved at once, which reads as a bug.
+        # The type check matters: `rate = 5` after `def rate(...)` is a value
+        # now, and must be pickled rather than restored as the old function.
+        if name in DEFS and isinstance(value, (types.FunctionType, type)):
+            continue
+        # Per variable, not the whole namespace at once: an open file or a
+        # socket would otherwise take every other variable down with it.
+        try:
+            blob = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+        except _b.Exception as exc:
+            skipped.append({"name": name, "reason": _b.type(exc).__name__})
+            continue
+        if _b.len(blob) > max_bytes or total + _b.len(blob) > max_bytes:
+            skipped.append({"name": name, "reason": "too large"})
+            continue
+        payload[name] = blob
+        total += _b.len(blob)
+
+    # Only definitions still present in the namespace; one the agent deleted or
+    # overwrote with a value should not come back.
+    live_defs = {n: src for n, src in DEFS.items() if n in NS and n not in payload}
+
+    tmp = path + ".tmp"
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with _b.open(tmp, "wb") as handle:
+            pickle.dump({"vars": payload, "modules": modules, "defs": live_defs}, handle, protocol=pickle.HIGHEST_PROTOCOL)
+        # Replaced, never written in place: a crash mid-write would otherwise
+        # leave a truncated file that fails to load on the next run.
+        os.replace(tmp, path)
+    except _b.Exception as exc:
+        try:
+            os.remove(tmp)
+        except _b.Exception:
+            pass
+        return {"ok": False, "error": "%s: %s" % (_b.type(exc).__name__, exc)}
+
+    return {
+        "ok": True,
+        "saved": _b.sorted(_b.list(payload) + _b.list(modules) + _b.list(live_defs)),
+        "skipped": skipped,
+        "bytes": total,
+    }
+
+
+def restore(path):
+    import builtins as _b
+    import importlib
+    import os
+    import pickle
+
+    if not os.path.exists(path):
+        return {"ok": True, "restored": [], "failed": []}
+
+    try:
+        with _b.open(path, "rb") as handle:
+            payload = pickle.load(handle)
+    except _b.Exception as exc:
+        # A corrupt or unreadable snapshot must not stop the kernel starting.
+        return {"ok": True, "restored": [], "failed": [{"name": "(file)", "reason": _b.str(exc)[:120]}]}
+
+    restored = []
+    failed = []
+
+    for alias, module_name in (payload or {}).get("modules", {}).items():
+        try:
+            NS[alias] = importlib.import_module(module_name)
+            restored.append(alias)
+        except _b.Exception as exc:
+            failed.append({"name": alias, "reason": _b.type(exc).__name__})
+
+    for name, blob in (payload or {}).get("vars", {}).items():
+        try:
+            NS[name] = pickle.loads(blob)
+            restored.append(name)
+        except _b.Exception as exc:
+            failed.append({"name": name, "reason": _b.type(exc).__name__})
+
+    # Definitions last: a helper that closes over a restored value needs that
+    # value to exist first.
+    for name, source in (payload or {}).get("defs", {}).items():
+        try:
+            exec(compile(source, "<restored>", "exec"), NS)
+            DEFS[name] = source
+            restored.append(name)
+        except _b.Exception as exc:
+            failed.append({"name": name, "reason": _b.type(exc).__name__})
+
+    return {"ok": True, "restored": _b.sorted(restored), "failed": failed}
+
+
 def main():
     while True:
         try:
@@ -138,6 +264,12 @@ def main():
         if kind == "tools":
             install_tools(msg.get("names") or [])
             reply({"ok": True, "installed": sorted(msg.get("names") or [])})
+            continue
+        if kind == "snapshot":
+            reply(snapshot(msg.get("path"), msg.get("maxBytes") or 32 * 1024 * 1024))
+            continue
+        if kind == "restore":
+            reply(restore(msg.get("path")))
             continue
         if kind == "bind":
             NS.update(msg.get("vars") or {})

--- a/src/tools/kernel.py
+++ b/src/tools/kernel.py
@@ -19,6 +19,11 @@ import traceback
 # The persistent namespace. Everything the agent defines lands here and stays.
 NS = {"__name__": "__cloi__", "__builtins__": __builtins__}
 
+# Names the host installed. Reported separately from the agent's own variables:
+# listing ten tool functions after every cell is noise, and the agent knows they
+# are there because it was told.
+INSTALLED = set()
+
 # Protocol writes must not be captured along with the code's own output, so the
 # real streams are captured once, before anything is ever redirected.
 PROTOCOL_OUT = sys.stdout
@@ -27,6 +32,55 @@ PROTOCOL_OUT = sys.stdout
 def reply(payload):
     PROTOCOL_OUT.write(json.dumps(payload) + "\n")
     PROTOCOL_OUT.flush()
+
+
+def read_message():
+    """One request line.
+
+    `sys.stdin.readline()` rather than iterating stdin: the iterator reads ahead
+    into a private buffer, which would swallow the reply to a tool call made
+    from inside a running cell.
+    """
+    line = sys.stdin.readline()
+    if not line:
+        return None
+    line = line.strip()
+    return json.loads(line) if line else {}
+
+
+class ToolError(RuntimeError):
+    """A tool ran and reported a failure. Catchable like any other exception."""
+
+
+def call_host(tool, kwargs):
+    """Run one of cloi's tools and return its output as a string.
+
+    Synchronous on purpose. The kernel is single-threaded and the host answers
+    one call at a time, so `text = read_file(path='a.js')` reads exactly like
+    the function call it appears to be.
+    """
+    reply({"type": "call", "tool": tool, "args": kwargs})
+    message = read_message()
+    if message is None:
+        raise ToolError("cloi closed the connection")
+    if not message.get("ok"):
+        raise ToolError(message.get("error") or ("%s failed" % tool))
+    return message.get("output", "")
+
+
+def install_tools(names):
+    """Bind each tool as a plain function in the namespace."""
+    for name in names:
+        def make(tool_name):
+            def call(**kwargs):
+                return call_host(tool_name, kwargs)
+            call.__name__ = tool_name
+            call.__doc__ = "cloi tool %r. Keyword arguments only; returns its output as a string." % tool_name
+            return call
+        NS[name] = make(name)
+        INSTALLED.add(name)
+    NS["ToolError"] = ToolError
+    INSTALLED.add("ToolError")
 
 
 def run(code):
@@ -65,21 +119,26 @@ def run(code):
 
 
 def names():
-    return sorted(k for k in NS if not k.startswith("_"))
+    return sorted(k for k in NS if not k.startswith("_") and k not in INSTALLED)
 
 
 def main():
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
+    while True:
         try:
-            msg = json.loads(line)
+            msg = read_message()
         except ValueError as exc:
             reply({"ok": False, "error": "bad request: %s" % exc})
             continue
+        if msg is None:
+            return
+        if not msg:
+            continue
 
         kind = msg.get("type")
+        if kind == "tools":
+            install_tools(msg.get("names") or [])
+            reply({"ok": True, "installed": sorted(msg.get("names") or [])})
+            continue
         if kind == "bind":
             NS.update(msg.get("vars") or {})
             reply({"ok": True, "bound": sorted((msg.get("vars") or {}).keys())})

--- a/src/tools/kernel.py
+++ b/src/tools/kernel.py
@@ -1,0 +1,97 @@
+"""Persistent Python kernel driver.
+
+Reads one JSON request per line from stdin, writes one JSON response per line to
+stdout. The namespace lives for the life of the process, which is the whole
+point: a variable bound in one call is still there in the next.
+
+Deliberately small. A Jupyter kernel would bring a dependency, a wire protocol
+and a discovery dance for what is, at this level, `exec` against a dict that
+never goes away.
+"""
+
+import ast
+import contextlib
+import io
+import json
+import sys
+import traceback
+
+# The persistent namespace. Everything the agent defines lands here and stays.
+NS = {"__name__": "__cloi__", "__builtins__": __builtins__}
+
+# Protocol writes must not be captured along with the code's own output, so the
+# real streams are captured once, before anything is ever redirected.
+PROTOCOL_OUT = sys.stdout
+
+
+def reply(payload):
+    PROTOCOL_OUT.write(json.dumps(payload) + "\n")
+    PROTOCOL_OUT.flush()
+
+
+def run(code):
+    out, err = io.StringIO(), io.StringIO()
+    value = None
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            # The *last* statement, not the whole cell, decides whether there is
+            # a value. Compiling the cell as an expression only works when it is
+            # a single line, so a cell that built a list and then named it
+            # returned nothing — which is not how a notebook behaves, and not
+            # what the tool description promises.
+            tree = ast.parse(code, "<cell>", "exec")
+            if tree.body and isinstance(tree.body[-1], ast.Expr):
+                head = ast.Module(body=tree.body[:-1], type_ignores=[])
+                tail = ast.Expression(body=tree.body[-1].value)
+                exec(compile(head, "<cell>", "exec"), NS)
+                value = eval(compile(tail, "<cell>", "eval"), NS)
+            else:
+                exec(compile(tree, "<cell>", "exec"), NS)
+        return {
+            "ok": True,
+            "stdout": out.getvalue(),
+            "stderr": err.getvalue(),
+            "value": None if value is None else repr(value),
+        }
+    except BaseException as exc:  # SystemExit and KeyboardInterrupt included
+        return {
+            "ok": False,
+            "stdout": out.getvalue(),
+            "stderr": err.getvalue(),
+            # Only the final frame: a traceback through this driver's own stack
+            # tells the agent nothing about its code.
+            "error": "".join(traceback.format_exception_only(type(exc), exc)).strip(),
+        }
+
+
+def names():
+    return sorted(k for k in NS if not k.startswith("_"))
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except ValueError as exc:
+            reply({"ok": False, "error": "bad request: %s" % exc})
+            continue
+
+        kind = msg.get("type")
+        if kind == "bind":
+            NS.update(msg.get("vars") or {})
+            reply({"ok": True, "bound": sorted((msg.get("vars") or {}).keys())})
+        elif kind == "names":
+            reply({"ok": True, "names": names()})
+        elif kind == "exec":
+            result = run(msg.get("code") or "")
+            result["names"] = names()
+            reply(result)
+        else:
+            reply({"ok": False, "error": "unknown request type %r" % kind})
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/python.js
+++ b/src/tools/python.js
@@ -27,6 +27,44 @@ import { kernelSnapshotPath } from '../util/paths.js';
 /** Output beyond this is cut before it reaches the transcript. */
 const MAX_LINES = 200;
 
+/**
+ * Worked cells, sent with the tool schema.
+ *
+ * A small model will not infer an API from a sentence. It costs tokens on every
+ * request, so each example earns its place by showing something the prose
+ * cannot: what a call actually looks like, that arguments are keyword-only, and
+ * that a failure is catchable rather than fatal to the cell.
+ *
+ * The last note is the one Prime Agent spends a paragraph on, and for good
+ * reason — a model will otherwise import the project into the scratchpad and
+ * draw conclusions from an environment that is not the project's.
+ */
+const EXAMPLES = `
+Examples:
+
+# A stored result is already a variable - do not fetch it again
+lines = [l for l in read_1.splitlines() if 'export' in l]
+len(lines)
+
+# Many tool calls in one cell, instead of one call per turn
+files = glob(pattern='src/**/*.js').splitlines()[1:]
+sizes = {f: len(read_file(path=f)) for f in files}
+sorted(sizes.items(), key=lambda kv: -kv[1])[:3]
+
+# A failing tool raises ToolError, so a loop can skip and carry on
+total = 0
+for f in files:
+    try:
+        total += read_file(path=f).count('TODO')
+    except ToolError:
+        continue
+total
+
+Notes:
+- Tool functions take keyword arguments only: read_file(path='a.js'), never read_file('a.js').
+- Do not run the project's tests, CLIs or imports here. Use run_command, so they run in the project's own environment.
+- Variables may already exist from an earlier session. Check before redefining them.`;
+
 export function registerPythonTool(registry) {
   registry.register({
     name: 'python',
@@ -39,7 +77,7 @@ export function registerPythonTool(registry) {
       + 'its output as a string — read_file(path=...), grep(pattern=...), run_command(command=...) '
       + '— so one cell can drive a whole loop of calls instead of one call per turn. A tool that '
       + 'fails raises ToolError, which you can catch; tools that normally ask permission still ask. '
-      + 'A bare expression on the last line returns its value, as in a REPL.',
+      + `A bare expression on the last line returns its value, as in a REPL.\n${EXAMPLES}`,
     permission: 'ask',
     parameters: {
       type: 'object',

--- a/src/tools/python.js
+++ b/src/tools/python.js
@@ -21,6 +21,7 @@
  */
 
 import { detectPython, kernelFor } from './kernel.js';
+import { DECISION } from '../agent/permission.js';
 
 /** Output beyond this is cut before it reaches the transcript. */
 const MAX_LINES = 200;
@@ -54,8 +55,10 @@ export function registerPythonTool(registry) {
       }
 
       const kernel = kernelFor(ctx.session?.id ?? 'default', { cwd: ctx.cwd, command });
+      kernel.onCall = (message) => serveTool(message, ctx);
 
       try {
+        await installCallableTools(kernel, ctx);
         await bindStoredResults(kernel, ctx.session);
         const result = await kernel.exec(args.code);
         return format(result);
@@ -66,6 +69,58 @@ export function registerPythonTool(registry) {
       }
     },
   });
+}
+
+/** A kernel calling itself would recurse; recall is redundant once bound. */
+const NOT_CALLABLE = new Set(['python', 'recall']);
+
+/**
+ * Expose cloi's tools as Python functions.
+ *
+ * Installed once per kernel. The set cannot change mid-session, so re-sending
+ * it on every cell would be a round-trip for nothing.
+ */
+async function installCallableTools(kernel, ctx) {
+  if (kernel.toolsInstalled) return;
+  const registry = ctx.registry;
+  if (!registry?.available) return;
+
+  const names = (await registry.available())
+    .map((tool) => tool.name)
+    .filter((name) => !NOT_CALLABLE.has(name));
+
+  await kernel.installTools(names);
+  kernel.toolsInstalled = true;
+}
+
+/**
+ * Run a tool for a cell that asked for it.
+ *
+ * The permission gate is the point. `python` being approved buys the *cell* a
+ * run, not everything the cell can reach — otherwise an approved scratchpad
+ * becomes a way to edit files and run shell commands with no prompt at all,
+ * which is precisely the gate the model would be routing around.
+ */
+async function serveTool({ tool: name, args }, ctx) {
+  const registry = ctx.registry;
+  if (!registry) throw new Error('tools are not available in this kernel');
+  if (NOT_CALLABLE.has(name)) throw new Error(`${name} cannot be called from Python`);
+
+  const tool = registry.get(name);
+  if (!tool) throw new Error(`no such tool: ${name}`);
+
+  if (tool.permission === 'ask') {
+    if (!ctx.permissions) throw new Error(`${name} needs approval, which is not available here`);
+    // request() answers with {decision, reason}, not a bare decision. Comparing
+    // the object to DECISION.ALLOW is always false — but written the other way
+    // round it would be always true, and every gated tool would sail through.
+    const { decision, reason } = await ctx.permissions.request(tool, args || {});
+    if (decision !== DECISION.ALLOW) throw new Error(reason || `${name} was not approved`);
+  }
+
+  const result = await registry.dispatch(name, args || {}, ctx);
+  if (result.isError) throw new Error(result.output);
+  return result.output;
 }
 
 /**

--- a/src/tools/python.js
+++ b/src/tools/python.js
@@ -22,6 +22,7 @@
 
 import { detectPython, kernelFor } from './kernel.js';
 import { DECISION } from '../agent/permission.js';
+import { kernelSnapshotPath } from '../util/paths.js';
 
 /** Output beyond this is cut before it reaches the transcript. */
 const MAX_LINES = 200;
@@ -54,14 +55,21 @@ export function registerPythonTool(registry) {
         return { output: 'No Python 3 interpreter is available.', isError: true };
       }
 
-      const kernel = kernelFor(ctx.session?.id ?? 'default', { cwd: ctx.cwd, command });
+      const sessionId = ctx.session?.id ?? 'default';
+      const kernel = kernelFor(sessionId, {
+        cwd: ctx.cwd,
+        command,
+        snapshotPath: kernelSnapshotPath(sessionId),
+      });
       kernel.onCall = (message) => serveTool(message, ctx);
 
       try {
         await installCallableTools(kernel, ctx);
         await bindStoredResults(kernel, ctx.session);
         const result = await kernel.exec(args.code);
-        return format(result);
+        // After the cell, not before: what is worth keeping is what it left.
+        kernel.scheduleSnapshot();
+        return format(result, kernel.takeRestoreNotice());
       } catch (err) {
         // A dead or hung kernel is a tool failure, not a turn-ending one: the
         // model can try something smaller, or fall back to the other tools.
@@ -143,8 +151,9 @@ async function bindStoredResults(kernel, session) {
 }
 
 /** Render a kernel reply the way a REPL would. */
-function format(result) {
+function format(result, notice) {
   const parts = [];
+  if (notice) parts.push(notice);
   if (result.stdout) parts.push(clip(result.stdout.replace(/\n$/, '')));
   if (result.stderr) parts.push(clip(result.stderr.replace(/\n$/, '')));
 

--- a/src/tools/python.js
+++ b/src/tools/python.js
@@ -32,11 +32,14 @@ export function registerPythonTool(registry) {
     name: 'python',
     description:
       'Run Python in a session-long interpreter. Variables, imports and functions persist '
-      + 'between calls, so results can be built up step by step. Every stored tool result is '
-      + 'already bound as a string variable under its handle (read_1, grep_2, …) — use those '
-      + 'instead of re-reading a file or repeating a search. A bare expression on the last line '
-      + 'returns its value, as in a REPL. This is a scratchpad for working with data you have '
-      + 'already gathered; use run_command to run the project\'s own tests and tools.',
+      + 'between calls and across sessions, so work can be built up step by step. '
+      + 'Every stored tool result is already bound as a string variable under its handle '
+      + '(read_1, grep_2, …) — use those instead of re-reading a file or repeating a search. '
+      + 'Every other tool is also callable as a function taking keyword arguments and returning '
+      + 'its output as a string — read_file(path=...), grep(pattern=...), run_command(command=...) '
+      + '— so one cell can drive a whole loop of calls instead of one call per turn. A tool that '
+      + 'fails raises ToolError, which you can catch; tools that normally ask permission still ask. '
+      + 'A bare expression on the last line returns its value, as in a REPL.',
     permission: 'ask',
     parameters: {
       type: 'object',

--- a/src/tools/python.js
+++ b/src/tools/python.js
@@ -110,7 +110,7 @@ export function registerPythonTool(registry) {
         const result = await kernel.exec(args.code);
         // After the cell, not before: what is worth keeping is what it left.
         kernel.scheduleSnapshot();
-        return format(result, kernel.takeRestoreNotice());
+        return format(result, kernel.takeRestoreNotice(), kernel.bound);
       } catch (err) {
         // A dead or hung kernel is a tool failure, not a turn-ending one: the
         // model can try something smaller, or fall back to the other tools.
@@ -192,7 +192,7 @@ async function bindStoredResults(kernel, session) {
 }
 
 /** Render a kernel reply the way a REPL would. */
-function format(result, notice) {
+function format(result, notice, bound = new Set()) {
   const parts = [];
   if (notice) parts.push(notice);
   if (result.stdout) parts.push(clip(result.stdout.replace(/\n$/, '')));
@@ -206,8 +206,11 @@ function format(result, notice) {
   if (result.value !== null && result.value !== undefined) parts.push(clip(result.value));
 
   // Bound handles are not news — the model knows those exist. What it needs
-  // back is what *this* cell left behind for the next one.
-  const defined = (result.names || []).filter((n) => !/^(read|grep|glob|ls|run|write|edit)_\d+$/.test(n));
+  // back is what *this* cell left behind for the next one. Filtered by what was
+  // actually bound rather than by the shape of a name: handles are named after
+  // their arguments now, so `stats_js` is indistinguishable from a variable the
+  // agent wrote itself.
+  const defined = (result.names || []).filter((n) => !bound.has(n));
   if (defined.length) parts.push(`[variables: ${defined.join(', ')}]`);
 
   // Only when there is genuinely nothing to say. A cell that assigns and prints

--- a/src/tools/python.js
+++ b/src/tools/python.js
@@ -1,0 +1,119 @@
+/**
+ * Python as a scratchpad, with tool results already in scope.
+ *
+ * The gap this closes: `recall` can search a stored result or slice it, and
+ * nothing else, because those were the two operations written by hand. Here
+ * every stored handle arrives as a Python string, so the agent can do whatever
+ * it likes with it — filter, count, intersect two results, build a table —
+ * without another round-trip to fetch anything.
+ *
+ *     lines = [l for l in read_1.splitlines() if 'export' in l]
+ *     len(lines)
+ *
+ * `read_1` was not fetched here. It was bound because a `read_file` call
+ * earlier in the session produced it, and the binding survives compaction for
+ * the same reason the handle does: it comes from the store, not the transcript.
+ *
+ * The kernel is additive. The ordinary tools remain, and a model that never
+ * writes Python is unaffected — which matters, because writing correct Python
+ * against live state is harder than emitting a tool call, and a bad line here
+ * can leave the namespace in a state later cells inherit.
+ */
+
+import { detectPython, kernelFor } from './kernel.js';
+
+/** Output beyond this is cut before it reaches the transcript. */
+const MAX_LINES = 200;
+
+export function registerPythonTool(registry) {
+  registry.register({
+    name: 'python',
+    description:
+      'Run Python in a session-long interpreter. Variables, imports and functions persist '
+      + 'between calls, so results can be built up step by step. Every stored tool result is '
+      + 'already bound as a string variable under its handle (read_1, grep_2, …) — use those '
+      + 'instead of re-reading a file or repeating a search. A bare expression on the last line '
+      + 'returns its value, as in a REPL. This is a scratchpad for working with data you have '
+      + 'already gathered; use run_command to run the project\'s own tests and tools.',
+    permission: 'ask',
+    parameters: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', description: 'Python source to execute in the persistent namespace.' },
+      },
+      required: ['code'],
+    },
+    // Missing Python is not an error to report at call time — the tool simply
+    // is not offered, so the model never reaches for something it cannot have.
+    check: () => !!detectPython(),
+
+    async execute(args, ctx) {
+      const command = detectPython();
+      if (!command) {
+        return { output: 'No Python 3 interpreter is available.', isError: true };
+      }
+
+      const kernel = kernelFor(ctx.session?.id ?? 'default', { cwd: ctx.cwd, command });
+
+      try {
+        await bindStoredResults(kernel, ctx.session);
+        const result = await kernel.exec(args.code);
+        return format(result);
+      } catch (err) {
+        // A dead or hung kernel is a tool failure, not a turn-ending one: the
+        // model can try something smaller, or fall back to the other tools.
+        return { output: err.message, isError: true };
+      }
+    },
+  });
+}
+
+/**
+ * Make every stored result available as a variable.
+ *
+ * Done before each cell rather than once at startup, because handles are
+ * created as the turn runs — a grep two steps ago should be in scope now.
+ * Already-bound names are skipped, so this costs nothing after the first call.
+ */
+async function bindStoredResults(kernel, session) {
+  if (typeof session?.listResults !== 'function') return;
+
+  const vars = {};
+  for (const row of session.listResults(50)) {
+    if (kernel.bound.has(row.name)) continue;
+    const stored = session.getResult(row.name);
+    if (stored) vars[row.name] = stored.content;
+  }
+  if (Object.keys(vars).length) await kernel.bind(vars);
+}
+
+/** Render a kernel reply the way a REPL would. */
+function format(result) {
+  const parts = [];
+  if (result.stdout) parts.push(clip(result.stdout.replace(/\n$/, '')));
+  if (result.stderr) parts.push(clip(result.stderr.replace(/\n$/, '')));
+
+  if (!result.ok) {
+    parts.push(result.error || 'Python raised an error.');
+    return { output: parts.join('\n') || 'Python raised an error.', isError: true };
+  }
+
+  if (result.value !== null && result.value !== undefined) parts.push(clip(result.value));
+
+  // Bound handles are not news — the model knows those exist. What it needs
+  // back is what *this* cell left behind for the next one.
+  const defined = (result.names || []).filter((n) => !/^(read|grep|glob|ls|run|write|edit)_\d+$/.test(n));
+  if (defined.length) parts.push(`[variables: ${defined.join(', ')}]`);
+
+  // Only when there is genuinely nothing to say. A cell that assigns and prints
+  // nothing is normal and successful, and an empty result reads as a failure.
+  if (!parts.length) parts.push('(no output)');
+
+  return { output: parts.join('\n') };
+}
+
+function clip(text) {
+  const lines = String(text).split('\n');
+  if (lines.length <= MAX_LINES) return lines.join('\n');
+  return `${lines.slice(0, MAX_LINES).join('\n')}\n… ${lines.length - MAX_LINES} more lines`;
+}

--- a/src/util/paths.js
+++ b/src/util/paths.js
@@ -14,6 +14,8 @@ export const DATA_DIR = process.env.CLOI_DATA_DIR || join(homedir(), '.cloi');
 export const DB_PATH = join(DATA_DIR, 'cloi.db');
 export const CONFIG_PATH = join(DATA_DIR, 'config.json');
 export const OVERFLOW_DIR = join(tmpdir(), 'cloi-overflow');
+/** Pickled Python namespaces, one per session. */
+export const KERNEL_DIR = join(DATA_DIR, 'kernels');
 
 /** Create a directory if absent. Safe to call repeatedly. */
 export function ensureDir(dir) {
@@ -42,4 +44,13 @@ export function pruneOverflow(maxAgeMs = 7 * 24 * 60 * 60 * 1000) {
       } catch {}
     }
   } catch {}
+}
+
+/** Where a session's Python namespace is kept between runs. */
+export function kernelSnapshotPath(sessionId) {
+  ensureDir(KERNEL_DIR);
+  // Session ids are UUIDs, but a path is built from this, so anything that is
+  // not one is reduced to something that cannot escape the directory.
+  const safe = String(sessionId).replace(/[^a-zA-Z0-9_-]/g, '');
+  return join(KERNEL_DIR, `${safe || 'default'}.pickle`);
 }

--- a/test/bench.test.js
+++ b/test/bench.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+/**
+ * The benchmark is evidence, so its own logic has to be right. A fixture where
+ * the answer is reachable by a shortcut measures nothing — which is exactly how
+ * the first version of this experiment scored 3/3 on a baseline that never
+ * touched the tool under test.
+ */
+test('the benchmark answer cannot be reached by counting exports alone', async () => {
+  const source = fs.readFileSync(new URL('../bench/python-tool.js', import.meta.url), 'utf8');
+  const files = [...source.matchAll(/\['(\w+)', (\d+), (\d+)\]/g)]
+    .map(([, name, exports, lines]) => ({ name, exports: +exports, lines: +lines }));
+
+  assert.ok(files.length >= 6, `parsed ${files.length} fixture files`);
+
+  const densest = files.reduce((a, b) => (a.exports / a.lines > b.exports / b.lines ? a : b));
+  const most = files.reduce((a, b) => (a.exports > b.exports ? a : b));
+  assert.notEqual(densest.name, most.name, 'a tally of exports must give the wrong answer');
+});
+
+test('stripping the examples leaves the rest of the description intact', async () => {
+  // The two arms must differ by the examples and nothing else, or the result
+  // measures something other than what it claims.
+  const { createRegistry } = await import('../src/tools/index.js');
+  const full = createRegistry().get('python').description;
+  const stripped = full.slice(0, full.indexOf('\nExamples:'));
+
+  assert.ok(stripped.length > 200, 'the prose survives');
+  assert.doesNotMatch(stripped, /^Examples:$/m);
+  assert.match(stripped, /callable as a function/, 'the capability is still described');
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Migration runs once at load, and loadConfig caches — so each case needs its
+ * own process to see a fresh read.
+ */
+function loadWith(saved) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloi-config-'));
+  fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify(saved, null, 2));
+  const target = new URL('../src/config.js', import.meta.url).href;
+  const out = execFileSync(process.execPath, ['--input-type=module', '--eval',
+    `const { loadConfig } = await import(${JSON.stringify(target)});
+     process.stdout.write(JSON.stringify(loadConfig()));`,
+  ], { env: { ...process.env, CLOI_DATA_DIR: dir }, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  return { config: JSON.parse(out), file: JSON.parse(fs.readFileSync(path.join(dir, 'config.json'), 'utf8')), dir };
+}
+
+test('a setting left at a superseded default follows the new one', () => {
+  // Observed live: a config written before `think` became capability-based
+  // still held `think: false`, which is the setting under which a reasoning
+  // model streams its monologue into the answer. The fix reached new installs
+  // only, so the bug persisted for everyone who already had cloi.
+  const { config, file, dir } = loadWith({ model: 'm', think: false, judgeAnswers: true });
+  assert.equal(config.think, null, 'think follows the model again');
+  assert.equal(config.judgeAnswers, null, 'reviews are back to escalation-only');
+  assert.ok(!('think' in file), 'and the stale value is removed from disk');
+  assert.equal(file.configVersion, 2, 'so it migrates once, not every run');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('a value the user actually changed is left alone', () => {
+  // Only values still equal to the old default are dropped.
+  const { config, dir } = loadWith({ model: 'm', think: true, judgeAnswers: false });
+  assert.equal(config.think, true);
+  assert.equal(config.judgeAnswers, false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('an already-migrated config is not touched again', () => {
+  // Otherwise a deliberate `think: false` set after the migration would be
+  // stripped on the next run, and every run after that.
+  const { config, dir } = loadWith({ model: 'm', think: false, configVersion: 2 });
+  assert.equal(config.think, false, 'a post-migration choice stands');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('everything else in the config survives migration', () => {
+  const { config, file, dir } = loadWith({ model: 'custom:7b', escalationModel: 'big:30b', think: false, autoApprove: ['grep'] });
+  assert.equal(config.model, 'custom:7b');
+  assert.equal(config.escalationModel, 'big:30b');
+  assert.deepEqual(config.autoApprove, ['grep']);
+  assert.equal(file.model, 'custom:7b', 'and is still on disk');
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/test/naming.test.js
+++ b/test/naming.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resultName } from '../src/session/naming.js';
+
+const name = (tool, args, taken) => resultName(tool, args, taken);
+
+test('a handle is named after what it holds', () => {
+  // `read_1` says which tool ran and in what order. The model has to fetch the
+  // result to remember what is in it.
+  assert.equal(name('read_file', { path: 'src/lib/stats.js' }), 'stats_js');
+  assert.equal(name('read_file', { path: 'README.md' }), 'readme_md');
+  assert.equal(name('grep', { pattern: 'completionRate' }), 'grep_completionrate');
+  assert.equal(name('glob', { pattern: '**/*.py' }), 'glob_py');
+  assert.equal(name('list_dir', { path: 'src/lib' }), 'ls_lib');
+});
+
+test('a command is named after the work, not the setup', () => {
+  assert.equal(name('run_command', { command: 'npm test' }), 'npm_test');
+  // `cd demo && python x.py` is about x.py; naming it `cd_demo` describes
+  // the directory change and nothing else.
+  assert.equal(name('run_command', { command: 'cd demo && python mpp.py' }), 'python_mpp_py');
+  assert.equal(name('run_command', { command: 'npm test --silent -w pkg' }), 'npm_test');
+});
+
+test('a name is always a usable Python identifier', () => {
+  // These are bound as variables in the kernel, so a name that is not an
+  // identifier is a SyntaxError the moment a cell touches it.
+  const identifier = /^[A-Za-z_][A-Za-z0-9_]*$/;
+  for (const [tool, args] of [
+    ['read_file', { path: '2024-report.txt' }],
+    ['read_file', { path: 'src/lib/my file (copy).js' }],
+    ['grep', { pattern: '^\s*export\s+' }],
+    ['read_file', { path: '../../weird/../path.js' }],
+    ['glob', { pattern: '***' }],
+    ['run_command', { command: '--flags-only' }],
+    ['read_file', { path: '' }],
+    ['read_file', {}],
+  ]) {
+    assert.match(resultName(tool, args), identifier, `bad identifier from ${JSON.stringify(args)}`);
+  }
+});
+
+test('a handle never shadows a tool function or a builtin', () => {
+  // A handle called `grep` would replace the tool function with a string, and
+  // the next cell calling grep(pattern=...) fails with something that looks
+  // nothing like the cause.
+  assert.notEqual(name('read_file', { path: 'grep' }), 'grep');
+  assert.notEqual(name('read_file', { path: 'list.py' }), 'list');
+  assert.equal(name('read_file', { path: 'open' }), 'read_open');
+  assert.equal(name('read_file', { path: 'class' }), 'read_class');
+});
+
+test('a repeat read gets its own name rather than replacing the first', () => {
+  // The earlier copy may predate an edit. Silently rebinding the name would
+  // hide that the file changed.
+  const used = new Set(['stats_js']);
+  const second = name('read_file', { path: 'src/stats.js' }, (n) => used.has(n));
+  assert.equal(second, 'stats_js_2');
+
+  used.add(second);
+  assert.equal(name('read_file', { path: 'src/stats.js' }, (n) => used.has(n)), 'stats_js_3');
+});
+
+test('names stay short enough to type in a cell', () => {
+  const long = name('read_file', { path: 'src/very/deep/an-extremely-long-file-name-that-goes-on.js' });
+  assert.ok(long.length <= 28, `${long} is ${long.length} chars`);
+  assert.match(long, /^[A-Za-z_][A-Za-z0-9_]*$/);
+});

--- a/test/prompt.test.js
+++ b/test/prompt.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSystemPrompt } from '../src/agent/prompt.js';
+
+const rulesOf = (toolNames) => buildSystemPrompt({ cwd: '/w', toolNames })
+  .split('\n').filter((l) => /^\d+\. /.test(l));
+
+test('the model is told about python only when it has python', async () => {
+  // Describing a tool the model was not given is worse than silence: it spends
+  // a turn calling something that is not there, and the repair costs another.
+  const withIt = rulesOf(['read_file', 'python']).join('\n');
+  const without = rulesOf(['read_file']).join('\n');
+  assert.match(withIt, /one python cell/);
+  assert.doesNotMatch(without, /python/);
+});
+
+test('rule numbering has no gaps whichever tools are present', () => {
+  // A model reading "1, 2, 4" wonders what it was not told.
+  for (const tools of [['read_file'], ['read_file', 'python'], []]) {
+    const numbers = rulesOf(tools).map((l) => Number(l.split('.')[0]));
+    assert.deepEqual(numbers, numbers.map((_, i) => i + 1), `gap with tools: ${tools}`);
+  }
+});
+
+test('batching is reconciled with taking one step at a time', () => {
+  // Rule 3 says one step at a time; a loop over fifty files in one cell could
+  // read as a violation, and a model that believes it is breaking a rule will
+  // not do it.
+  const withIt = rulesOf(['python']).join('\n');
+  assert.match(withIt, /the cell is the step/);
+});
+
+test('the rules survive being asked for with no tools at all', () => {
+  // buildSystemPrompt is called before availability is known in some paths.
+  assert.ok(rulesOf(undefined).length >= 5);
+  assert.doesNotMatch(buildSystemPrompt({ cwd: '/w' }), /undefined/);
+});

--- a/test/python.test.js
+++ b/test/python.test.js
@@ -256,3 +256,131 @@ test('installed tools are not reported as the agent\'s variables', needsPython, 
   assert.doesNotMatch(result.output, /read_file/);
   shutdownKernels();
 });
+
+/** A snapshot path in a directory nothing else touches. */
+async function snapshotPath() {
+  const fsp = await import('node:fs');
+  const osp = await import('node:os');
+  const pathp = await import('node:path');
+  const dir = fsp.mkdtempSync(pathp.join(osp.tmpdir(), 'cloi-snap-'));
+  return pathp.join(dir, 'ns.pickle');
+}
+
+test('variables survive a new process', needsPython, async () => {
+  // The kernel dies with its process; the namespace should not.
+  const snap = await snapshotPath();
+  const first = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  await first.exec('counts = {"a": 1, "b": 2}');
+  await first.snapshot();
+  first.kill();
+
+  const second = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  try {
+    assert.equal((await second.exec('counts["a"] + counts["b"]')).value, '3');
+  } finally {
+    second.kill();
+  }
+});
+
+test('imports and definitions come back too', needsPython, async () => {
+  // pickle stores a function by reference, so a helper written in a cell cannot
+  // be serialised — and a helper the agent wrote is exactly what is worth
+  // keeping. Its source is replayed instead. Modules likewise: the name is
+  // enough to import them again.
+  const snap = await snapshotPath();
+  const first = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  await first.exec('import json');
+  await first.exec('def rate(done, total):\n    return round(done / total, 2)');
+  await first.exec('class Row:\n    def __init__(self, n):\n        self.n = n');
+  await first.snapshot();
+  first.kill();
+
+  const second = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  try {
+    assert.equal((await second.exec('json.dumps([1])')).value, "'[1]'");
+    assert.equal((await second.exec('rate(3, 4)')).value, '0.75');
+    assert.equal((await second.exec('Row(7).n')).value, '7');
+  } finally {
+    second.kill();
+  }
+});
+
+test('one unsaveable variable does not cost the others', needsPython, async () => {
+  // Per-variable, not the whole namespace at once: an open file would otherwise
+  // take every other variable down with it.
+  const snap = await snapshotPath();
+  const kernel = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  try {
+    await kernel.exec('kept = [1, 2, 3]\nhandle = open("package.json")');
+    const saved = await kernel.snapshot();
+    assert.ok(saved.saved.includes('kept'));
+    assert.ok(saved.skipped.some((s) => s.name === 'handle'), 'and the loss is reported');
+    // A name must not be reported as saved and skipped at once.
+    const both = saved.saved.filter((n) => saved.skipped.some((s) => s.name === n));
+    assert.deepEqual(both, []);
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('a name rebound to a value is restored as that value', needsPython, async () => {
+  // `rate = 5` after `def rate(...)` is a number now, and replaying the old
+  // definition over it would silently resurrect the function.
+  const snap = await snapshotPath();
+  const first = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  await first.exec('def thing():\n    return 1');
+  await first.exec('thing = 99');
+  await first.snapshot();
+  first.kill();
+
+  const second = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  try {
+    assert.equal((await second.exec('thing')).value, '99');
+  } finally {
+    second.kill();
+  }
+});
+
+test('a corrupt snapshot does not stop the kernel starting', needsPython, async () => {
+  // Losing variables is a nuisance; refusing to start is a broken session.
+  const fsp = await import('node:fs');
+  const snap = await snapshotPath();
+  fsp.writeFileSync(snap, 'not a pickle at all');
+
+  const kernel = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  try {
+    assert.equal((await kernel.exec('1 + 1')).value, '2');
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('a missing snapshot is simply an empty namespace', needsPython, async () => {
+  const snap = await snapshotPath();
+  const kernel = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  try {
+    assert.equal((await kernel.exec('2 + 2')).value, '4');
+    assert.equal(kernel.takeRestoreNotice(), null, 'nothing to report on a first run');
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('what was restored is reported once, not every cell', needsPython, async () => {
+  // The agent needs to know its variables came back, or it redefines them —
+  // and repeating it after every cell would be noise.
+  const snap = await snapshotPath();
+  const first = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  await first.exec('saved_value = 5');
+  await first.snapshot();
+  first.kill();
+
+  const second = new PythonKernel({ cwd: process.cwd(), snapshotPath: snap });
+  try {
+    await second.exec('saved_value');
+    assert.match(second.takeRestoreNotice(), /restored from the last session: saved_value/);
+    assert.equal(second.takeRestoreNotice(), null, 'reported once');
+  } finally {
+    second.kill();
+  }
+});

--- a/test/python.test.js
+++ b/test/python.test.js
@@ -163,3 +163,96 @@ test('the tool is withheld when there is no interpreter', async () => {
   const offered = (await createRegistry().available()).map((t) => t.name);
   assert.equal(offered.includes('python'), !!python);
 });
+
+/** A registry plus a permission manager that records what it was asked. */
+async function harness({ answer = async () => 'allow' } = {}) {
+  const { createRegistry } = await import('../src/tools/index.js');
+  const { PermissionManager } = await import('../src/agent/permission.js');
+  const asked = [];
+  const registry = createRegistry();
+  const permissions = new PermissionManager({
+    ask: async (request) => { asked.push(request.tool.name); return answer(request); },
+  });
+  const session = { id: `t${asked.length}-${Math.random()}`, listResults: () => [], getResult: () => null };
+  return {
+    asked,
+    run: (code) => registry.dispatch('python', { code }, {
+      cwd: process.cwd(), session, ui: {}, registry, permissions,
+    }),
+  };
+}
+
+test('a tool can be called as a function and its output used', needsPython, async () => {
+  const { run } = await harness();
+  const result = await run("text = read_file(path='package.json')\n'\"name\"' in text");
+  assert.match(result.output, /True/);
+  shutdownKernels();
+});
+
+test('one cell can drive many tool calls', needsPython, async () => {
+  // The point of calling out rather than being fed in: a loop over results
+  // costs one model round-trip instead of one per file.
+  const { run } = await harness();
+  const result = await run(
+    "names = ['package.json', 'README.md']\n"
+    + 'sizes = [len(read_file(path=n)) for n in names]\n'
+    + 'len(sizes)',
+  );
+  assert.match(result.output, /2/);
+  shutdownKernels();
+});
+
+test('a gated tool called from Python still asks', needsPython, async () => {
+  // Approving the scratchpad must not approve everything the scratchpad can
+  // reach, or the permission gate is simply routed around.
+  const { run, asked } = await harness({ answer: async () => 'deny' });
+  const result = await run("edit_file(path='README.md', old_string='a', new_string='b')");
+  assert.equal(result.isError, true);
+  assert.match(result.output, /declined/);
+  assert.ok(asked.includes('edit_file'), 'the user must have been asked');
+  shutdownKernels();
+});
+
+test('a safe tool called from Python does not ask', needsPython, async () => {
+  const { run, asked } = await harness();
+  await run("read_file(path='package.json')");
+  assert.equal(asked.includes('read_file'), false);
+  shutdownKernels();
+});
+
+test('a failing tool raises a catchable ToolError', needsPython, async () => {
+  // A tool failure is information, not a dead cell — the code around it should
+  // be able to decide what to do.
+  const { run } = await harness();
+  const result = await run(
+    'try:\n'
+    + "    read_file(path='does-not-exist.txt')\n"
+    + '    caught = None\n'
+    + 'except ToolError as e:\n'
+    + '    caught = str(e)\n'
+    + 'caught',
+  );
+  assert.match(result.output, /File not found/);
+  assert.equal(result.isError, false, 'the cell handled it, so the cell succeeded');
+  shutdownKernels();
+});
+
+test('python cannot call itself', needsPython, async () => {
+  // Recursion through the bridge would deadlock: the kernel is single-threaded
+  // and the outer cell is blocked waiting for the inner one.
+  const { run } = await harness();
+  const result = await run("python(code='1')");
+  assert.equal(result.isError, true);
+  assert.match(result.output, /NameError|cannot be called/);
+  shutdownKernels();
+});
+
+test('installed tools are not reported as the agent\'s variables', needsPython, async () => {
+  // Ten function names after every cell is noise; what matters is what this
+  // cell left for the next one.
+  const { run } = await harness();
+  const result = await run('kept = 1');
+  assert.match(result.output, /\[variables: kept\]/);
+  assert.doesNotMatch(result.output, /read_file/);
+  shutdownKernels();
+});

--- a/test/python.test.js
+++ b/test/python.test.js
@@ -1,0 +1,165 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { detectPython, PythonKernel, shutdownKernels } from '../src/tools/kernel.js';
+
+const python = detectPython();
+/** Every kernel test needs a real interpreter; without one the tool is not offered. */
+const needsPython = { skip: python ? false : 'no Python 3 on PATH' };
+
+test('detection runs the interpreter rather than trusting the name', needsPython, () => {
+  // On Windows `python3` is often an App Execution Alias that prints "Python
+  // was not found…" and exits 0. A `which`-style check calls that a success and
+  // the kernel then dies at the first cell with nothing to explain it.
+  assert.ok(['python3', 'python', 'py'].includes(python));
+  const probe = spawnSync(python, ['-c', 'import sys; print(sys.version_info[0])'], { encoding: 'utf8' });
+  assert.equal(probe.stdout.trim(), '3', 'the detected command must really be Python 3');
+});
+
+test('a variable outlives the call that created it', needsPython, async () => {
+  // The whole point of a kernel over a subprocess per call.
+  const kernel = new PythonKernel({ cwd: process.cwd() });
+  try {
+    await kernel.exec('total = 0');
+    await kernel.exec('total += 21');
+    const result = await kernel.exec('total * 2');
+    assert.equal(result.ok, true);
+    assert.equal(result.value, '42');
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('the last expression of a multi-line cell is the value', needsPython, async () => {
+  // Compiling the whole cell as an expression only works for a single line, so
+  // a cell that built a list and then named it used to return nothing.
+  const kernel = new PythonKernel({ cwd: process.cwd() });
+  try {
+    const result = await kernel.exec('rows = [1, 2, 3]\nsum(rows)');
+    assert.equal(result.value, '6');
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('a cell that only assigns is a success, not an empty failure', needsPython, async () => {
+  const kernel = new PythonKernel({ cwd: process.cwd() });
+  try {
+    const result = await kernel.exec('x = 1');
+    assert.equal(result.ok, true);
+    assert.equal(result.value, null);
+    assert.ok(result.names.includes('x'), 'the caller needs to know what was defined');
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('an error is reported without killing the namespace', needsPython, async () => {
+  // A failed cell must not cost every variable built before it.
+  const kernel = new PythonKernel({ cwd: process.cwd() });
+  try {
+    await kernel.exec('keep = "still here"');
+    const failed = await kernel.exec('1 / 0');
+    assert.equal(failed.ok, false);
+    assert.match(failed.error, /ZeroDivisionError/);
+    // The driver's own frames say nothing about the agent's code.
+    assert.doesNotMatch(failed.error, /kernel\.py/);
+
+    const after = await kernel.exec('keep');
+    assert.equal(after.value, "'still here'");
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('stdout and the value are both reported', needsPython, async () => {
+  const kernel = new PythonKernel({ cwd: process.cwd() });
+  try {
+    const result = await kernel.exec('print("working")\n7');
+    assert.equal(result.stdout.trim(), 'working');
+    assert.equal(result.value, '7');
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('bound values arrive as real Python strings', needsPython, async () => {
+  const kernel = new PythonKernel({ cwd: process.cwd() });
+  try {
+    await kernel.bind({ grep_1: 'alpha\nbeta\ngamma' });
+    const result = await kernel.exec("len([l for l in grep_1.splitlines() if 'a' in l])");
+    assert.equal(result.value, '3');
+    // Binding twice is a no-op, so a long session does not resend everything.
+    const again = await kernel.bind({ grep_1: 'changed' });
+    assert.deepEqual(again.bound, []);
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('a hung cell is killed rather than blocking the session', needsPython, async () => {
+  // The kernel is single-threaded: one cell that never returns would otherwise
+  // block every cell after it for the rest of the session.
+  const kernel = new PythonKernel({ cwd: process.cwd(), timeoutMs: 700 });
+  try {
+    await assert.rejects(
+      () => kernel.exec('import time; time.sleep(30)'),
+      /did not finish within/,
+    );
+    // And the loss of state is stated rather than left to be discovered.
+    assert.equal(kernel.running, false);
+  } finally {
+    kernel.kill();
+  }
+});
+
+test('the kernel does not inherit the parent\'s secrets', needsPython, async () => {
+  // Same containment as run_command: a subprocess started by the agent has no
+  // business seeing the API keys of the shell that launched cloi.
+  process.env.CLOI_TEST_FAKE_API_KEY = 'sk-must-not-leak';
+  const kernel = new PythonKernel({ cwd: process.cwd() });
+  try {
+    const result = await kernel.exec('import os; os.environ.get("CLOI_TEST_FAKE_API_KEY", "absent")');
+    assert.equal(result.value, "'absent'");
+  } finally {
+    kernel.kill();
+    delete process.env.CLOI_TEST_FAKE_API_KEY;
+  }
+});
+
+test('the python tool binds stored results before running', needsPython, async () => {
+  // The bridge: a handle created by an earlier tool call is in scope without
+  // being fetched, which is what recall could never do.
+  // Only the two methods the binding uses. The real store is exercised by the
+  // recall tests; coupling this to it would mean opening a session database
+  // that node:sqlite then holds for the life of the process.
+  const stored = { grep_1: 'one\ntwo\nthree' };
+  const session = {
+    id: 'bind-test',
+    listResults: () => Object.keys(stored).map((name) => ({ name })),
+    getResult: (name) => (stored[name] ? { name, content: stored[name] } : null),
+  };
+
+  const { createRegistry } = await import('../src/tools/index.js');
+  const result = await createRegistry().dispatch(
+    'python', { code: 'len(grep_1.splitlines())' }, { cwd: process.cwd(), session, ui: {} },
+  );
+  assert.match(result.output, /3/);
+
+  // A handle created later in the same session is bound on the next cell.
+  stored.read_1 = 'a\nb';
+  const later = await createRegistry().dispatch(
+    'python', { code: 'len(read_1.splitlines())' }, { cwd: process.cwd(), session, ui: {} },
+  );
+  assert.match(later.output, /2/, 'new handles must reach an already-running kernel');
+
+  shutdownKernels();
+});
+
+test('the tool is withheld when there is no interpreter', async () => {
+  // Offering a tool that cannot run teaches the model to call something that
+  // always fails. Registry availability checks exist for exactly this.
+  const { createRegistry } = await import('../src/tools/index.js');
+  const offered = (await createRegistry().available()).map((t) => t.name);
+  assert.equal(offered.includes('python'), !!python);
+});

--- a/test/python.test.js
+++ b/test/python.test.js
@@ -384,3 +384,19 @@ test('what was restored is reported once, not every cell', needsPython, async ()
     second.kill();
   }
 });
+
+test('the description carries worked examples, not just prose', async () => {
+  // Measured: with these, nemotron-3-nano:4b reached for the kernel 8/8 runs
+  // and answered 3/8; without them, 0/8 and 0/8. A small model will not infer
+  // an API from a sentence.
+  const { createRegistry } = await import('../src/tools/index.js');
+  const description = createRegistry().get('python').description;
+
+  assert.match(description, /^Examples:$/m);
+  // Each example must show something the prose cannot.
+  assert.match(description, /read_1\.splitlines\(\)/, 'a stored handle in use');
+  assert.match(description, /read_file\(path=f\)/, 'a tool called inside a loop');
+  assert.match(description, /except ToolError/, 'a failure being handled');
+  assert.match(description, /keyword arguments only/, 'the calling convention');
+  assert.match(description, /run_command, so they run in the project/, 'what not to use it for');
+});

--- a/test/recall.test.js
+++ b/test/recall.test.js
@@ -22,13 +22,16 @@ async function recall(session, args) {
   return createRegistry().dispatch('recall', args, { cwd: session.cwd, session, ui: {} });
 }
 
-test('handles are named after the tool and numbered per tool', async () => {
+test('handles are named after what they hold', async () => {
+  // A name carrying the subject means the model does not have to fetch a
+  // result to remember what is in it.
   const { session, dir } = await freshSession();
-  assert.equal(session.saveResult({ toolName: 'read_file', args: { path: 'a.js' }, content: 'x' }), 'read_1');
-  assert.equal(session.saveResult({ toolName: 'read_file', args: { path: 'b.js' }, content: 'x' }), 'read_2');
-  // A different tool counts separately, so the number means something.
-  assert.equal(session.saveResult({ toolName: 'grep', args: { pattern: 'q' }, content: 'x' }), 'grep_1');
-  assert.equal(session.saveResult({ toolName: 'run_command', args: { command: 'npm test' }, content: 'x' }), 'run_1');
+  assert.equal(session.saveResult({ toolName: 'read_file', args: { path: 'a.js' }, content: 'x' }), 'a_js');
+  assert.equal(session.saveResult({ toolName: 'read_file', args: { path: 'b.js' }, content: 'x' }), 'b_js');
+  assert.equal(session.saveResult({ toolName: 'grep', args: { pattern: 'q' }, content: 'x' }), 'grep_q');
+  assert.equal(session.saveResult({ toolName: 'run_command', args: { command: 'npm test' }, content: 'x' }), 'npm_test');
+  // The same file twice keeps both: the earlier copy may predate an edit.
+  assert.equal(session.saveResult({ toolName: 'read_file', args: { path: 'a.js' }, content: 'y' }), 'a_js_2');
   cleanup(dir);
 });
 
@@ -83,9 +86,9 @@ test('an unknown handle lists what does exist', async () => {
   const { session, dir } = await freshSession();
   session.saveResult({ toolName: 'grep', args: { pattern: 'x' }, content: 'hit' });
 
-  const missing = await recall(session, { name: 'read_9' });
+  const missing = await recall(session, { name: 'nothing_here' });
   assert.equal(missing.isError, true);
-  assert.match(missing.output, /grep_1/, 'the model needs to see the real names');
+  assert.match(missing.output, /grep_x/, 'the model needs to see the real names');
   cleanup(dir);
 });
 
@@ -96,7 +99,7 @@ test('calling recall with no name lists the stored results', async () => {
 
   session.saveResult({ toolName: 'read_file', args: { path: 'src/a.js' }, content: 'x'.repeat(50) });
   const listed = await recall(session, {});
-  assert.match(listed.output, /read_1/);
+  assert.match(listed.output, /a_js/);
   assert.match(listed.output, /src\/a\.js/, 'the arguments make a handle recognisable');
   cleanup(dir);
 });


### PR DESCRIPTION
Builds toward Prime Agent's model of results-as-variables, adapted to a harness that has no kernel and runs 4B models.

## What this adds

A `python` tool backed by a **session-long interpreter**. Every stored result handle arrives bound as a variable:

```python
lines = [l for l in read_1.splitlines() if l.startswith('## ')]
len(lines)
```

`read_1` is not fetched here — an earlier `read_file` produced it, and the handle holds the **whole file**, not the window that was shown. Variables, imports and functions persist between calls, and a bare expression on the last line returns its value as in a notebook.

This closes the gap left by `recall`, which could only search or slice because those were the two operations written by hand. A result is now something to compute over.

## Verified live

```
multi-line cell ending in an expression: 17
compose two results: ['Answer verification', 'Architecture', 'Choosing models']
namespace survives an error: 17
```

## Deliberately additive

The ordinary tools remain and a model that never writes Python is unaffected. Writing correct code against live state is harder than emitting a tool call, and a bad line leaves a namespace later cells inherit — so this is an option, not a replacement.

- asks permission like `run_command`
- same sanitised environment, so a cell cannot read your API keys (tested)
- **withheld entirely** when no interpreter is present, rather than failing at call time
- a cell that hangs is killed after 30s; the kernel is single-threaded, so one hung cell would block every cell after it

## Two traps worth naming

**Detection runs the interpreter rather than trusting the name.** On Windows `python3` is frequently an App Execution Alias that prints "Python was not found" and **exits 0** — a `which`-style check reports success and the kernel then dies at the first cell with nothing to explain it.

**A multi-line cell ending in an expression returned nothing.** Compiling the whole cell as an expression only works for a single line. The last statement now decides, via `ast`.

224 tests pass, 11 of them new.